### PR TITLE
feat(whitelabel): retire a cancelled merchant's App Store listing, and stop claiming the rest (#702)

### DIFF
--- a/.planning/quick/260908-pa1-proapp-teardown/PLAN.md
+++ b/.planning/quick/260908-pa1-proapp-teardown/PLAN.md
@@ -73,9 +73,27 @@ The failure being fixed is *a system reporting teardown of something it never
 touched*. Every part of this must refuse to do a smaller version of that:
 
 - a row seeded with no Apple id must not advance as though it tore something down
-- Play and Firebase returning `ErrNotWired` must be **visible on the row and in
-  the logs**, never swallowed so the state machine can proceed to
-  `credentials_purged`
+- Play and Firebase must be **visibly not-torn-down**, never silently skipped on
+  the way to `credentials_purged`
+
+  **CORRECTED 2026-09-08, during T1 — the plan had this wrong, and it was wrong
+  because two of its own decisions interact.** The `ErrNotWired` log path is
+  UNREACHABLE for Play: `advancer.go:173,190` guard both call sites with
+  `if r.GooglePackage != ""`, and decision 4 leaves that field empty by design.
+  So Play is never attempted, never errors, and never logs — the row advances to
+  `credentials_purged` having said nothing at all about it. That is the exact
+  "reports teardown of something it never touched" failure this plan exists to
+  prevent, reintroduced by the plan itself.
+
+  T2 must therefore make Play's absence explicit through something OTHER than the
+  `ErrNotWired` path — a durable statement on the row and a log at seed time
+  saying Play teardown will not be attempted, and why (no package identifier, and
+  the client is a stub). Firebase does not have this problem: decision 5
+  populates `FirebaseProjectID`, so `archiveFirebase` reaches the stub and logs.
+
+  Do not "fix" this by populating `GooglePackage` with a placeholder to make the
+  guard fire. That trades a silent skip for a row that claims an identifier it
+  does not have, and decision 4 exists to prevent exactly that.
 - ambiguous discovery must refuse, not pick
 
 ## Tasks

--- a/.planning/quick/260908-pa1-proapp-teardown/PLAN.md
+++ b/.planning/quick/260908-pa1-proapp-teardown/PLAN.md
@@ -107,6 +107,27 @@ touched*. Every part of this must refuse to do a smaller version of that:
   row. Assert the emit still happens when discovery fails — a failed teardown
   must not swallow the audit event.
 
+- **T3 — production stops using fake clients.** Added 2026-09-08 after T2, which
+  found the gap. `main.go:2469-2471` wires **all three** whitelabel clients as
+  fakes, Apple included. So the advancer calls a fake `BlockDownloads`/`PullApp`
+  and then writes `downloads_blocked` and `pulled` — a row asserting a teardown
+  that touched nothing. Latent today because nothing seeds rows; **T2 is what
+  fills the table**, and the consumer's own comment says an immediate
+  cancellation seeds a row already overdue, so the advancer acts on the next
+  tick. T2 therefore must not merge without this.
+
+  Three parts, and the second two are as important as the first:
+
+  1. `Config.Apple` becomes a per-row factory — `apple.Client`'s `CredsFetcher`
+     takes no tenant, so one client structurally cannot serve a multi-tenant
+     cohort. Reuse the `AppleListerFactory` shape T2 already built.
+  2. **Google and Firebase move from fakes to their REAL stubs.** The fakes are
+     strictly less honest: `firebase.FakeClient.ArchiveProject` returns
+     `f.ArchiveErr`, nil by default — a *silent success* having done nothing —
+     while the real client returns `ErrNotWired`, which `archiveFirebase` logs.
+     T2 populates `FirebaseProjectID`, so this path IS reached.
+  3. Nothing may report a teardown it did not perform. That is the whole issue.
+
 ## Done means
 
 - [ ] A cancelled Pro+App store seeds `white_label_app_state` with a real Apple id

--- a/.planning/quick/260908-pa1-proapp-teardown/PLAN.md
+++ b/.planning/quick/260908-pa1-proapp-teardown/PLAN.md
@@ -1,0 +1,98 @@
+---
+id: 260908-pa1
+slug: proapp-teardown
+date: 2026-09-08
+issue: 702
+kind: quick
+branch: feat/702-discover-apple-app-at-teardown
+---
+
+# A cancelled Pro+App merchant's App Store listing actually gets pulled (#702)
+
+When a Pro+App merchant cancels, `finalize.go:88` emits
+`subscription.pro_app_cancelled` and then logs that it "would notify" a service
+that does not exist. The consumer that would retire the app is written, tested,
+and **never constructed**. Nothing seeds `white_label_app_state`, so the advancer
+runs forever over an empty table and the merchant's app stays live indefinitely.
+
+## Three gaps, not the two the issue names
+
+Measured 2026-09-08:
+
+1. **The consumer is never constructed** and there is no delivery path from the
+   emit to `Handle`. (#702 names this.)
+2. **No source for the identifiers it needs.** (#702 names this.)
+3. **Two of the three teardown clients are unimplemented stubs.** `googleplay`
+   and `firebase` return `ErrNotWired` from every method. Only `apple` is real —
+   it makes genuine ASC calls with ES256-JWT auth. **#702 does not name this**,
+   and it caps what any amount of wiring can achieve.
+
+## Scope, decided 2026-09-08
+
+**Apple only, and the limitation is stated rather than implied.**
+
+This makes App Store teardown genuinely work — the surface with the strongest
+obligation, since a published listing under merchant branding is the most
+visible thing we keep operating for someone who has stopped paying. Play and
+Firebase remain `ErrNotWired`.
+
+**#702 does not close on this.** It goes from "nothing is torn down" to "the App
+Store listing is retired; Play and Firebase are not, visibly."
+
+## Decisions, settled — do not re-open these
+
+1. **Discover, do not record.** Identifiers are resolved at teardown from the
+   credentials already stored, not written down at provisioning — there is no
+   provisioning flow to hang that on. See #702's analysis comment.
+2. **Discovery must run BEFORE the day-90 credential purge.** `app_credentials.go`
+   states the advancer purges all four credential types at day 90. A teardown
+   that reaches `credentials_purged` without having discovered anything has
+   permanently lost the ability to. Seed at cancel time, not lazily.
+3. **Ambiguity fails loudly.** If ASC returns more than one app, do NOT guess.
+   A wrong app id pulls a listing belonging to a merchant who did not cancel,
+   which is worse than not pulling one. Refuse with a named error, the same
+   discipline `ErrNoAppIdentifiers` (#711) already set.
+4. **`GooglePackage` stays empty.** There is no source and the client is a stub;
+   inventing one would seed a row that walks the state machine reporting
+   teardown of something that never happened.
+5. **`FirebaseProjectID` comes from the service-account JSON's `project_id`**,
+   which `ValidateGooglePlayJSON` already parses and discards. Record that it is
+   the *GCP* project of the service account — usually the Firebase project for a
+   Firebase-backed app, not guaranteed. The Firebase client is a stub anyway, so
+   nothing acts on it yet; capturing it now costs nothing and is honest about
+   what it is.
+6. **The delivery path is an interface the emitter owns**, not pub/sub and not a
+   direct import of `whitelabel/lifecycle` from `subscription/lifecycle`.
+   `FinalizeCron` gains a small notifier interface it defines; `main.go` wires
+   the real consumer into it. Pub/Sub is what `finalize.go`'s comment defers to,
+   and it is not needed for an in-process call.
+
+## THE LESSON THIS TASK EXISTS UNDER
+
+The failure being fixed is *a system reporting teardown of something it never
+touched*. Every part of this must refuse to do a smaller version of that:
+
+- a row seeded with no Apple id must not advance as though it tore something down
+- Play and Firebase returning `ErrNotWired` must be **visible on the row and in
+  the logs**, never swallowed so the state machine can proceed to
+  `credentials_purged`
+- ambiguous discovery must refuse, not pick
+
+## Tasks
+
+- **T1 — `ListApps` on the Apple client.** `GET /v1/apps` using the existing
+  `call`/auth path, on `ClientAPI`, the real `Client`, and `FakeClient`. Returns
+  the app ids the merchant's ASC credentials can see.
+- **T2 — discovery + the delivery path.** A notifier interface on `FinalizeCron`;
+  `main.go` constructs `ProAppCancelledConsumer` and wires it. On cancel:
+  discover the Apple id (refusing on 0 or >1), read the SA `project_id`, seed the
+  row. Assert the emit still happens when discovery fails — a failed teardown
+  must not swallow the audit event.
+
+## Done means
+
+- [ ] A cancelled Pro+App store seeds `white_label_app_state` with a real Apple id
+- [ ] More than one ASC app refuses by name; zero refuses by name
+- [ ] The audit event is emitted whether or not discovery succeeds
+- [ ] Play and Firebase `ErrNotWired` is visible, and does not advance the row
+- [ ] #702 updated: what now works, what does not, and that it stays open

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -134,9 +134,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/webhook/ssrfguard"
 	"github.com/mark8ly/marketplace-api/internal/webhookevents"
 	"github.com/mark8ly/marketplace-api/internal/webhookprune"
-	wlapple "github.com/mark8ly/marketplace-api/internal/whitelabel/apple"
 	wlfirebase "github.com/mark8ly/marketplace-api/internal/whitelabel/firebase"
-	wlgoogleplay "github.com/mark8ly/marketplace-api/internal/whitelabel/googleplay"
 	wllifecycle "github.com/mark8ly/marketplace-api/internal/whitelabel/lifecycle"
 	"github.com/mark8ly/marketplace-api/internal/wishlist"
 	"github.com/mark8ly/marketplace-api/pkg/config"
@@ -2330,10 +2328,9 @@ func main() {
 			WithDiscovery(&wllifecycle.Discovery{
 				// A REAL App Store Connect client, built per tenant from
 				// that tenant's stored credentials — a FakeClient here
-				// would see zero apps and refuse every teardown. Note
-				// the asymmetry with the advancer below, which is still
-				// wired to wlapple.NewFakeClient(): discovery reads for
-				// real, the day-30/60 writes do not yet.
+				// would see zero apps and refuse every teardown. The
+				// advancer below is wired the same way, so the day-30/60
+				// writes reach Apple for real too.
 				Apple:  wllifecycle.NewAppleListerFactory(wlAppCredsSvc),
 				Creds:  wlAppCredsSvc,
 				Logger: log,
@@ -2452,11 +2449,19 @@ func main() {
 	// for dev so `make dev` boots without GCP auth. Every read/write/
 	// delete emits an audit event + increments a Prometheus counter.
 	//
-	// Apple/Google/Firebase clients: wired as FakeClient today — real
-	// integrations return ErrNotWired until the respective API SDKs are
-	// fleshed out in a follow-up. The lifecycle advancer tolerates
-	// ErrNotWired (logged, swallowed) so day-30/60/90 actions can land
-	// progressively as each integration matures.
+	// Apple/Google/Firebase clients: all three are the REAL
+	// implementations. Fakes here would have been worse than nothing —
+	// apple.FakeClient's BlockDownloads/PullApp succeed without calling
+	// Apple, and firebase.FakeClient.ArchiveProject returns a nil error
+	// by default, so the advancer would write downloads_blocked, pulled
+	// and firebase_archived into the append-only lifecycle table for a
+	// teardown that touched nothing (#702 T3). Play and Firebase are
+	// still stubs, but their stubs return ErrNotWired, which the advancer
+	// logs — an honest "not done" instead of a silent success.
+	//
+	// Apple and Google are wired as per-tenant FACTORIES: their
+	// credentials are per-tenant and the advancer walks a multi-tenant
+	// cohort, so there is no single client that can serve it.
 	//
 	// The lifecycle cron registers on the shared trialScheduler so it
 	// shares the same thread pool and shutdown semantics as P5/P6/P11
@@ -2466,14 +2471,11 @@ func main() {
 	// MODE=storefront it's nil and we skip the lifecycle cron — the
 	// storefront pod has no business running the teardown advancer.
 	if wlAppCredsSvc != nil {
-		wlAppleCli := wlapple.NewFakeClient()
-		wlGoogleCli := wlgoogleplay.NewFakeClient()
-		wlFirebaseCli := wlfirebase.NewFakeClient()
 		wlAdvancer := wllifecycle.NewAdvancer(wllifecycle.Config{
 			DB:       conn,
-			Apple:    wlAppleCli,
-			Google:   wlGoogleCli,
-			Firebase: wlFirebaseCli,
+			Apple:    wllifecycle.NewAppleTeardownFactory(wlAppCredsSvc),
+			Google:   wllifecycle.NewGoogleTeardownFactory(wlAppCredsSvc),
+			Firebase: wlfirebase.New(),
 			Creds:    wlAppCredsSvc,
 			Clock:    time.Now,
 			Logger:   log,

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -2310,7 +2310,40 @@ func main() {
 	p11SubscriptionRepo := subscription.NewRepository()
 	p11HardDeleteRunner := harddelete.NewRunner(conn, billingStripeClient, auditEmitter, log)
 
-	finalizeCron := lifecycle.NewFinalizeCron(conn, auditEmitter, log, nil)
+	// P15 delivery path (#702). The finalize cron used to emit
+	// subscription.pro_app_cancelled and then log that it "would notify"
+	// a service that was never built; this is that service, called
+	// in-process through the small notifier interface the subscription
+	// package defines.
+	//
+	// The consumer discovers the App Store app id HERE, at cancellation,
+	// rather than lazily at day 30/60: the advancer purges every stored
+	// credential at day 90, including the ASC key discovery asks with.
+	//
+	// proAppNotifier stays a TRUE nil interface when wlAppCredsSvc is nil
+	// (MODE=storefront) — a typed nil would satisfy FinalizeCron's
+	// `notifier != nil` check and then fail on first use, the #288 shape.
+	var proAppNotifier lifecycle.ProAppTeardownNotifier
+	if wlAppCredsSvc != nil {
+		proAppNotifier = wllifecycle.NewProAppCancelledConsumer(conn, nil).
+			WithLogger(log).
+			WithDiscovery(&wllifecycle.Discovery{
+				// A REAL App Store Connect client, built per tenant from
+				// that tenant's stored credentials — a FakeClient here
+				// would see zero apps and refuse every teardown. Note
+				// the asymmetry with the advancer below, which is still
+				// wired to wlapple.NewFakeClient(): discovery reads for
+				// real, the day-30/60 writes do not yet.
+				Apple:  wllifecycle.NewAppleListerFactory(wlAppCredsSvc),
+				Creds:  wlAppCredsSvc,
+				Logger: log,
+			})
+	} else {
+		log.Info("P15 pro-app teardown notifier not wired (MODE=storefront, wlAppCredsSvc nil)")
+	}
+
+	finalizeCron := lifecycle.NewFinalizeCron(conn, auditEmitter, log, nil).
+		WithProAppTeardownNotifier(proAppNotifier)
 	if _, err := trialScheduler.AddFunc(lifecycle.FinalizeSpec, func() {
 		if err := finalizeCron.Run(workerCtx); err != nil {
 			log.Error("lifecycle finalize cron failed", "err", err)

--- a/services/marketplace-api/internal/billing/appcreds/validate.go
+++ b/services/marketplace-api/internal/billing/appcreds/validate.go
@@ -51,6 +51,40 @@ func ValidateP8(payload []byte) error {
 	return nil
 }
 
+// serviceAccount is the subset of a Google service-account JSON that this
+// package reads. Both ValidateGooglePlayJSON and GooglePlayProjectID go
+// through parseServiceAccount so there is exactly one definition of what
+// a well-formed payload is; a second inline json.Unmarshal elsewhere would
+// be free to disagree with this one about what "valid" means.
+type serviceAccount struct {
+	Type        string `json:"type"`
+	ProjectID   string `json:"project_id"`
+	PrivateKey  string `json:"private_key"`
+	ClientEmail string `json:"client_email"`
+}
+
+// parseServiceAccount decodes and validates a Google Play service-account
+// JSON. Returns a wrapped ErrInvalidGooglePlayJSON on any failure.
+func parseServiceAccount(payload []byte) (serviceAccount, error) {
+	var sa serviceAccount
+	if err := json.Unmarshal(payload, &sa); err != nil {
+		return serviceAccount{}, fmt.Errorf("%w: parse json: %v", ErrInvalidGooglePlayJSON, err)
+	}
+	if sa.Type != "service_account" {
+		return serviceAccount{}, fmt.Errorf("%w: type %q; want service_account", ErrInvalidGooglePlayJSON, sa.Type)
+	}
+	if sa.ProjectID == "" {
+		return serviceAccount{}, fmt.Errorf("%w: missing project_id", ErrInvalidGooglePlayJSON)
+	}
+	if sa.PrivateKey == "" {
+		return serviceAccount{}, fmt.Errorf("%w: missing private_key", ErrInvalidGooglePlayJSON)
+	}
+	if sa.ClientEmail == "" {
+		return serviceAccount{}, fmt.Errorf("%w: missing client_email", ErrInvalidGooglePlayJSON)
+	}
+	return sa, nil
+}
+
 // ValidateGooglePlayJSON asserts the payload is a Google service-account
 // JSON (not a user-authorized OAuth credential). Checks:
 //   - valid JSON
@@ -59,26 +93,28 @@ func ValidateP8(payload []byte) error {
 //
 // Returns a wrapped ErrInvalidGooglePlayJSON on any failure.
 func ValidateGooglePlayJSON(payload []byte) error {
-	var sa struct {
-		Type        string `json:"type"`
-		ProjectID   string `json:"project_id"`
-		PrivateKey  string `json:"private_key"`
-		ClientEmail string `json:"client_email"`
+	_, err := parseServiceAccount(payload)
+	return err
+}
+
+// GooglePlayProjectID returns the "project_id" of a Google Play
+// service-account JSON, running the same validation ValidateGooglePlayJSON
+// does (same parser, same wrapped ErrInvalidGooglePlayJSON).
+//
+// WHAT THIS IDENTIFIER ACTUALLY IS: the GCP project that owns the service
+// account, which is not by definition the merchant's Firebase project.
+// Firebase projects ARE GCP projects and the Play publisher service
+// account is conventionally created inside the same one, so for a
+// Firebase-backed white-label app the two are the same string in
+// practice — but nothing enforces that, and a merchant who created the
+// publisher SA in a separate project will yield a project id that has no
+// Firebase resources at all. A caller recording this as a Firebase
+// project id (#702 teardown discovery) is recording a strong inference,
+// not a verified fact.
+func GooglePlayProjectID(payload []byte) (string, error) {
+	sa, err := parseServiceAccount(payload)
+	if err != nil {
+		return "", err
 	}
-	if err := json.Unmarshal(payload, &sa); err != nil {
-		return fmt.Errorf("%w: parse json: %v", ErrInvalidGooglePlayJSON, err)
-	}
-	if sa.Type != "service_account" {
-		return fmt.Errorf("%w: type %q; want service_account", ErrInvalidGooglePlayJSON, sa.Type)
-	}
-	if sa.ProjectID == "" {
-		return fmt.Errorf("%w: missing project_id", ErrInvalidGooglePlayJSON)
-	}
-	if sa.PrivateKey == "" {
-		return fmt.Errorf("%w: missing private_key", ErrInvalidGooglePlayJSON)
-	}
-	if sa.ClientEmail == "" {
-		return fmt.Errorf("%w: missing client_email", ErrInvalidGooglePlayJSON)
-	}
-	return nil
+	return sa.ProjectID, nil
 }

--- a/services/marketplace-api/internal/billing/appcreds/validate_test.go
+++ b/services/marketplace-api/internal/billing/appcreds/validate_test.go
@@ -139,3 +139,44 @@ func TestValidateGooglePlayJSON_RejectsInvalidJSON(t *testing.T) {
 		t.Errorf("err = %v, want wraps ErrInvalidGooglePlayJSON", err)
 	}
 }
+
+// ─── GooglePlayProjectID (#702 teardown discovery) ───────────────────
+
+func TestGooglePlayProjectID_ReturnsProjectID(t *testing.T) {
+	payload := []byte(`{
+	  "type": "service_account",
+	  "project_id": "merchant-app-42",
+	  "private_key": "-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----\n",
+	  "client_email": "play@merchant-app-42.iam.gserviceaccount.com"
+	}`)
+
+	got, err := GooglePlayProjectID(payload)
+	if err != nil {
+		t.Fatalf("GooglePlayProjectID: %v", err)
+	}
+	if got != "merchant-app-42" {
+		t.Fatalf("project id = %q, want merchant-app-42", got)
+	}
+}
+
+// The reader and the validator must agree on what a valid payload is —
+// that is the whole reason they share one parser.
+func TestGooglePlayProjectID_RejectsWhatValidateRejects(t *testing.T) {
+	cases := map[string][]byte{
+		"not json":           []byte(`{`),
+		"authorized_user":    []byte(`{"type":"authorized_user","project_id":"p","private_key":"k","client_email":"e"}`),
+		"missing project_id": []byte(`{"type":"service_account","private_key":"k","client_email":"e"}`),
+	}
+	for name, payload := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, readErr := GooglePlayProjectID(payload)
+			validateErr := ValidateGooglePlayJSON(payload)
+			if readErr == nil || validateErr == nil {
+				t.Fatalf("both must reject: read=%v validate=%v", readErr, validateErr)
+			}
+			if !errors.Is(readErr, ErrInvalidGooglePlayJSON) {
+				t.Fatalf("read error must wrap ErrInvalidGooglePlayJSON, got %v", readErr)
+			}
+		})
+	}
+}

--- a/services/marketplace-api/internal/subscription/lifecycle/finalize.go
+++ b/services/marketplace-api/internal/subscription/lifecycle/finalize.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/audit"
@@ -29,6 +30,31 @@ const FinalizeSpec = "0 1 * * *"
 // P15 listens for this event to trigger app teardown.
 const ActionProAppCancelled = "subscription.pro_app_cancelled"
 
+// ProAppTeardownNotifier is the delivery path from this cron to whatever
+// retires a cancelled Pro+App merchant's mobile app listings.
+//
+// It is declared HERE, by the emitter, rather than imported from
+// internal/whitelabel/lifecycle, for two reasons. Importing the consumer
+// package directly would make the subscription lifecycle depend on the
+// white-label teardown machinery to compile, which inverts the real
+// dependency — teardown is downstream of cancellation, not the other way
+// round. And a Pub/Sub topic (what the "deferred" comment this replaced
+// pointed at) would add a broker, a subscription, a delivery failure
+// mode and an at-least-once contract to an in-process call between two
+// packages in the same binary, buying nothing.
+//
+// Implemented by *whitelabel/lifecycle.ProAppCancelledConsumer; wired in
+// cmd/marketplace-api/main.go.
+type ProAppTeardownNotifier interface {
+	ProAppCancelled(ctx context.Context, tenantID, storeID uuid.UUID) error
+}
+
+// proAppNotifyTimeout bounds one store's teardown seeding. The notifier
+// makes network calls to App Store Connect; without a bound, one hung
+// connection would stall every remaining store's finalisation behind it,
+// since finalizeOne runs serially over the cohort.
+const proAppNotifyTimeout = 60 * time.Second
+
 // FinalizeCron transitions cancel_scheduled → expired for subscriptions whose
 // current_period_end has passed (or is nil — treat as already ended).
 // Idempotent: double-runs produce ErrCASConflict which is swallowed.
@@ -37,6 +63,22 @@ type FinalizeCron struct {
 	emitter *audit.Emitter
 	logger  *slog.Logger
 	clock   func() time.Time
+	// notifier is optional: nil means no teardown path is wired, which
+	// is logged as a warning at the point it would have been used
+	// rather than passing silently.
+	notifier ProAppTeardownNotifier
+}
+
+// WithProAppTeardownNotifier returns a copy of the cron that hands
+// cancelled Pro+App stores to n.
+//
+// Pass a TRUE nil interface (not a typed nil) to disable — see the
+// trialStripe comment in main.go for why a typed nil would defeat the
+// nil check below.
+func (c *FinalizeCron) WithProAppTeardownNotifier(n ProAppTeardownNotifier) *FinalizeCron {
+	next := *c
+	next.notifier = n
+	return &next
 }
 
 // NewFinalizeCron constructs a FinalizeCron.
@@ -87,24 +129,7 @@ func (c *FinalizeCron) finalizeOne(ctx context.Context, row *subscription.StoreS
 		// Pro+App hook: if the store had the white-label app add-on, emit
 		// subscription.pro_app_cancelled so P15 can trigger app teardown.
 		if row.HasWhiteLabelAppAddOn {
-			c.emitter.Emit(nil, audit.Event{
-				Action:         ActionProAppCancelled,
-				ResourceType:   "subscription",
-				ResourceID:     row.StoreID.String(),
-				Severity:       audit.SeverityWarning,
-				TenantID:       row.TenantID,
-				StoreID:        row.StoreID,
-				ForceActorType: audit.ActorSystem,
-				Metadata: map[string]any{
-					"reason":   "cancel_scheduled_finalized",
-					"store_id": row.StoreID.String(),
-				},
-			})
-			// P15 listens for this audit event (or pub/sub topic — deferred).
-			// Until P15 is wired, log intent so ops can see it.
-			c.logger.Info("lifecycle: would notify pro-app service",
-				"store_id", row.StoreID,
-				"action", ActionProAppCancelled)
+			c.onProAppCancelled(ctx, row)
 		}
 	case errors.Is(err, statemachine.ErrCASConflict):
 		// Another writer already moved this row — skip silently.
@@ -114,4 +139,50 @@ func (c *FinalizeCron) finalizeOne(ctx context.Context, row *subscription.StoreS
 		c.logger.Error("lifecycle: finalize cancel transition failed",
 			"store_id", row.StoreID, "err", err)
 	}
+}
+
+// onProAppCancelled records the cancellation and hands the store to the
+// teardown notifier.
+//
+// ORDER IS LOAD-BEARING: the audit event is emitted FIRST and
+// unconditionally. Whether the app teardown can be seeded is a separate
+// question from whether the cancellation happened, and a teardown that
+// fails must not also erase the record that a Pro+App subscription
+// ended. The event is the audit trail; the notifier is an action taken
+// because of it.
+func (c *FinalizeCron) onProAppCancelled(ctx context.Context, row *subscription.StoreSubscription) {
+	c.emitter.Emit(nil, audit.Event{
+		Action:         ActionProAppCancelled,
+		ResourceType:   "subscription",
+		ResourceID:     row.StoreID.String(),
+		Severity:       audit.SeverityWarning,
+		TenantID:       row.TenantID,
+		StoreID:        row.StoreID,
+		ForceActorType: audit.ActorSystem,
+		Metadata: map[string]any{
+			"reason":   "cancel_scheduled_finalized",
+			"store_id": row.StoreID.String(),
+		},
+	})
+
+	if c.notifier == nil {
+		c.logger.Warn("lifecycle: pro-app teardown notifier not wired — the merchant's app listings will not be retired",
+			"store_id", row.StoreID, "tenant_id", row.TenantID, "action", ActionProAppCancelled)
+		return
+	}
+
+	nctx, cancel := context.WithTimeout(ctx, proAppNotifyTimeout)
+	defer cancel()
+	if err := c.notifier.ProAppCancelled(nctx, row.TenantID, row.StoreID); err != nil {
+		// Logged and swallowed: one store whose identifiers could not be
+		// resolved must not stall the rest of the cohort's finalisation.
+		// The subscription IS expired either way — the transition above
+		// already committed — so this is a teardown that did not start,
+		// not a cancellation that did not happen.
+		c.logger.Error("lifecycle: pro-app teardown not seeded — the merchant's app listings stay live",
+			"store_id", row.StoreID, "tenant_id", row.TenantID, "err", err)
+		return
+	}
+	c.logger.Info("lifecycle: pro-app teardown seeded",
+		"store_id", row.StoreID, "tenant_id", row.TenantID, "action", ActionProAppCancelled)
 }

--- a/services/marketplace-api/internal/subscription/lifecycle/finalize_pro_app_test.go
+++ b/services/marketplace-api/internal/subscription/lifecycle/finalize_pro_app_test.go
@@ -1,0 +1,160 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/audit"
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+)
+
+// captureRepo records the audit rows the Emitter's worker writes,
+// standing in for the database so the emit path can be asserted without
+// one.
+type captureRepo struct {
+	mu      sync.Mutex
+	entries []audit.Entry
+}
+
+func (r *captureRepo) Create(_ context.Context, _ *gorm.DB, e *audit.Entry) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.entries = append(r.entries, *e)
+	return nil
+}
+
+func (r *captureRepo) actions() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, 0, len(r.entries))
+	for _, e := range r.entries {
+		out = append(out, e.Action)
+	}
+	return out
+}
+
+func (r *captureRepo) List(context.Context, *gorm.DB, audit.ListFilter) (audit.ListResult, error) {
+	return audit.ListResult{}, nil
+}
+
+func (r *captureRepo) Stream(context.Context, *gorm.DB, audit.ListFilter, func(*audit.Entry) error) error {
+	return nil
+}
+
+func (r *captureRepo) ListPlatform(context.Context, *gorm.DB, audit.PlatformListFilter) (audit.ListResult, error) {
+	return audit.ListResult{}, nil
+}
+
+// stubNotifier records the calls the finalize cron makes and can fail.
+type stubNotifier struct {
+	err    error
+	calls  int
+	tenant uuid.UUID
+	store  uuid.UUID
+}
+
+func (s *stubNotifier) ProAppCancelled(_ context.Context, tenantID, storeID uuid.UUID) error {
+	s.calls++
+	s.tenant, s.store = tenantID, storeID
+	return s.err
+}
+
+func newCapturingCron(t *testing.T, n ProAppTeardownNotifier) (*FinalizeCron, *captureRepo) {
+	t.Helper()
+	repo := &captureRepo{}
+	em, err := audit.NewEmitter(audit.EmitterConfig{Repo: repo, Logger: slog.Default()})
+	require.NoError(t, err)
+	// No t.Cleanup Stop: every test drains explicitly, and Emitter.Stop
+	// closes a channel, so a second call panics.
+	cron := NewFinalizeCron(nil, em, slog.Default(), nil).WithProAppTeardownNotifier(n)
+	return cron, repo
+}
+
+// drain stops the emitter so its async worker has written everything
+// before assertions read the capture.
+func drain(t *testing.T, em *audit.Emitter) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*audit.WriteTimeout)
+	defer cancel()
+	em.Stop(ctx)
+}
+
+func proAppRow() *subscription.StoreSubscription {
+	return &subscription.StoreSubscription{
+		TenantID:              uuid.New(),
+		StoreID:               uuid.New(),
+		HasWhiteLabelAppAddOn: true,
+	}
+}
+
+// The audit event is the record that a Pro+App cancellation happened. A
+// teardown that cannot be seeded must not also erase it.
+func TestOnProAppCancelled_EmitsEvenWhenDiscoveryFails(t *testing.T) {
+	n := &stubNotifier{err: errors.New("boom: App Store Connect saw two apps")}
+	cron, repo := newCapturingCron(t, n)
+
+	row := proAppRow()
+	cron.onProAppCancelled(context.Background(), row)
+	drain(t, cron.emitter)
+
+	require.Equal(t, 1, n.calls, "the notifier must still be called")
+	require.Contains(t, repo.actions(), ActionProAppCancelled,
+		"the cancellation audit event must be emitted even though teardown seeding failed")
+}
+
+func TestOnProAppCancelled_EmitsAndNotifiesOnSuccess(t *testing.T) {
+	n := &stubNotifier{}
+	cron, repo := newCapturingCron(t, n)
+
+	row := proAppRow()
+	cron.onProAppCancelled(context.Background(), row)
+	drain(t, cron.emitter)
+
+	require.Equal(t, 1, n.calls)
+	require.Equal(t, row.TenantID, n.tenant)
+	require.Equal(t, row.StoreID, n.store)
+	require.Contains(t, repo.actions(), ActionProAppCancelled)
+}
+
+// A nil notifier is a wiring state, not a crash: the event is still
+// recorded and the missing path is warned about.
+func TestOnProAppCancelled_NoNotifierWired(t *testing.T) {
+	cron, repo := newCapturingCron(t, nil)
+
+	require.NotPanics(t, func() {
+		cron.onProAppCancelled(context.Background(), proAppRow())
+	})
+	drain(t, cron.emitter)
+	require.Contains(t, repo.actions(), ActionProAppCancelled)
+}
+
+// The notifier gets a bounded context so one hung App Store Connect call
+// cannot stall the rest of the cohort's finalisation.
+func TestOnProAppCancelled_NotifierContextHasDeadline(t *testing.T) {
+	var deadline time.Time
+	var ok bool
+	cron, _ := newCapturingCron(t, notifierFunc(func(ctx context.Context, _, _ uuid.UUID) error {
+		deadline, ok = ctx.Deadline()
+		return nil
+	}))
+
+	cron.onProAppCancelled(context.Background(), proAppRow())
+	drain(t, cron.emitter)
+
+	require.True(t, ok, "notifier must be called with a deadline")
+	require.WithinDuration(t, time.Now().Add(proAppNotifyTimeout), deadline, 5*time.Second)
+}
+
+type notifierFunc func(ctx context.Context, tenantID, storeID uuid.UUID) error
+
+func (f notifierFunc) ProAppCancelled(ctx context.Context, tenantID, storeID uuid.UUID) error {
+	return f(ctx, tenantID, storeID)
+}

--- a/services/marketplace-api/internal/whitelabel/apple/client.go
+++ b/services/marketplace-api/internal/whitelabel/apple/client.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -41,7 +42,43 @@ type ClientAPI interface {
 
 	// PullApp removes the public listing for appID. Idempotent.
 	PullApp(ctx context.Context, appleAppID string) error
+
+	// ListApps returns every app the credentials can see. Read-only —
+	// it never mutates anything at Apple. Used to discover the Apple
+	// app id at teardown time from credentials already stored (#702).
+	ListApps(ctx context.Context) ([]App, error)
 }
+
+// App is one resource from GET /v1/apps. ID is the Apple app id that
+// BlockDownloads and PullApp take. BundleID and Name are carried for
+// diagnostics: a caller refusing an ambiguous result needs to say which
+// apps it saw, and an opaque numeric id alone is not a useful log line.
+type App struct {
+	ID       string
+	BundleID string
+	Name     string
+}
+
+// ErrUnauthorized reports that App Store Connect rejected the
+// credentials (401/403) — typically a revoked or expired .p8 key. It is
+// deliberately a distinct sentinel from "the account has no apps": the
+// first means we do not know what exists, the second means we do know
+// and the answer is nothing. A caller that conflates them would refuse
+// teardown for the wrong reason (#702).
+var ErrUnauthorized = errors.New("apple: App Store Connect rejected the credentials")
+
+// ErrTooManyAppPages reports that /v1/apps had more pages than
+// listAppsMaxPages. See the pagination note on ListApps.
+var ErrTooManyAppPages = errors.New("apple: /v1/apps exceeded the page cap")
+
+const (
+	// listAppsPageLimit is Apple's documented maximum page size for
+	// /v1/apps; asking for it keeps the common case to one request.
+	listAppsPageLimit = 200
+
+	// listAppsMaxPages bounds paging at 2000 apps.
+	listAppsMaxPages = 10
+)
 
 // Credentials is the bundle read from appcreds.Service.Load at call
 // time — never stored on the Client struct. Enforces "fetch fresh
@@ -131,6 +168,130 @@ func (c *Client) PullApp(ctx context.Context, appleAppID string) error {
 	}
 	path := fmt.Sprintf("/v1/apps/%s", appleAppID)
 	return c.call(ctx, http.MethodPatch, path, body)
+}
+
+// ListApps returns every app visible to the stored App Store Connect
+// credentials, via GET /v1/apps.
+//
+// This is a READ. It issues only GET requests and mutates nothing at
+// Apple; BlockDownloads and PullApp remain the only write paths.
+//
+// PAGINATION — deliberate choice: we follow links.next, capped at
+// listAppsMaxPages pages of listAppsPageLimit each, and return
+// ErrTooManyAppPages rather than truncating. Reading only the first page
+// would silently omit apps once an account crosses 200, and the caller
+// (teardown discovery) decides based on how many apps it saw — a
+// truncated list can turn an ambiguous account into a falsely
+// unambiguous one and pull the wrong listing. Unbounded paging is the
+// opposite failure, so the cap is explicit and loud when hit.
+func (c *Client) ListApps(ctx context.Context) ([]App, error) {
+	base, err := url.Parse(c.baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("apple: parse base url: %w", err)
+	}
+
+	next := fmt.Sprintf("%s/v1/apps?limit=%d", c.baseURL, listAppsPageLimit)
+	var apps []App
+
+	for page := 0; next != ""; page++ {
+		if page >= listAppsMaxPages {
+			return nil, fmt.Errorf("%w (%d pages)", ErrTooManyAppPages, listAppsMaxPages)
+		}
+
+		var doc appsDocument
+		if err := c.getJSON(ctx, next, &doc); err != nil {
+			return nil, err
+		}
+		for _, r := range doc.Data {
+			apps = append(apps, App{
+				ID:       r.ID,
+				BundleID: r.Attributes.BundleID,
+				Name:     r.Attributes.Name,
+			})
+		}
+
+		next, err = sameHostNext(base, doc.Links.Next)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return apps, nil
+}
+
+// sameHostNext validates a links.next value before we follow it. Apple
+// returns an absolute URL; refusing one that points at a different host
+// keeps a compromised or unexpected response from redirecting an
+// authenticated request (we send the Bearer token on every hop).
+func sameHostNext(base *url.URL, raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("apple: parse links.next: %w", err)
+	}
+	if u.Scheme != base.Scheme || u.Host != base.Host {
+		return "", fmt.Errorf("apple: links.next points off-host (%s)", u.Host)
+	}
+	return u.String(), nil
+}
+
+// appsDocument is the JSON:API document returned by GET /v1/apps.
+type appsDocument struct {
+	Data []struct {
+		ID         string `json:"id"`
+		Attributes struct {
+			BundleID string `json:"bundleId"`
+			Name     string `json:"name"`
+		} `json:"attributes"`
+	} `json:"data"`
+	Links struct {
+		Next string `json:"next"`
+	} `json:"links"`
+}
+
+// getJSON is the read counterpart to call. It exists as a separate
+// helper because call is shaped for the two write operations: it
+// discards the response body, and it maps 404 to nil because
+// re-removing an already-removed app is a success. Neither is correct
+// for a read — a read needs the body, and a 404 is an answer we do not
+// have rather than an answer of "none". Auth and request assembly are
+// the same and stay in one place per caller by construction.
+func (c *Client) getJSON(ctx context.Context, rawURL string, out any) error {
+	creds, err := c.credsFetcher(ctx)
+	if err != nil {
+		return fmt.Errorf("apple: fetch creds: %w", err)
+	}
+	token, err := SignJWT(creds.P8, creds.IssuerID, creds.KeyID, c.tokenLifetime)
+	if err != nil {
+		return fmt.Errorf("apple: sign jwt: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("apple: GET %s: %w", rawURL, err)
+	}
+	defer resp.Body.Close()
+
+	switch {
+	case resp.StatusCode == http.StatusOK:
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return fmt.Errorf("apple: decode GET %s: %w", rawURL, err)
+		}
+		return nil
+	case resp.StatusCode == http.StatusUnauthorized, resp.StatusCode == http.StatusForbidden:
+		return fmt.Errorf("%w: GET %s: status %d", ErrUnauthorized, rawURL, resp.StatusCode)
+	default:
+		return fmt.Errorf("apple: GET %s: unexpected status %d", rawURL, resp.StatusCode)
+	}
 }
 
 // call wraps request assembly + auth + response classification.

--- a/services/marketplace-api/internal/whitelabel/apple/fake.go
+++ b/services/marketplace-api/internal/whitelabel/apple/fake.go
@@ -17,6 +17,13 @@ type FakeClient struct {
 	// named error — used to exercise the advancer's error path.
 	BlockDownloadsErr error
 	PullAppErr        error
+
+	// Apps is what ListApps returns; ListAppsErr overrides it. Zero,
+	// one and many are all expressible so callers can be tested against
+	// each — an empty account and a rejected key are different facts.
+	Apps              []App
+	ListAppsErr       error
+	ListAppsCallCount int
 }
 
 // NewFakeClient is a convenience zero-value constructor.
@@ -36,4 +43,18 @@ func (f *FakeClient) PullApp(_ context.Context, appleAppID string) error {
 	f.PullAppCallCount++
 	f.PulledAppIDs = append(f.PulledAppIDs, appleAppID)
 	return f.PullAppErr
+}
+
+func (f *FakeClient) ListApps(context.Context) ([]App, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ListAppsCallCount++
+	if f.ListAppsErr != nil {
+		return nil, f.ListAppsErr
+	}
+	// Copy: ListApps is a read, and a caller must not be able to mutate
+	// the fake's state through the slice it gets back.
+	out := make([]App, len(f.Apps))
+	copy(out, f.Apps)
+	return out, nil
 }

--- a/services/marketplace-api/internal/whitelabel/apple/list_apps_test.go
+++ b/services/marketplace-api/internal/whitelabel/apple/list_apps_test.go
@@ -1,0 +1,354 @@
+package apple_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mark8ly/marketplace-api/internal/whitelabel/apple"
+)
+
+// recordedRequest captures what the client actually sent, so the tests
+// assert the request and not merely the parsed result — a client that
+// never authenticated would still satisfy a parse-only assertion.
+type recordedRequest struct {
+	Method string
+	Path   string
+	Query  string
+	Auth   string
+}
+
+type ascRecorder struct {
+	mu   sync.Mutex
+	reqs []recordedRequest
+}
+
+func (r *ascRecorder) record(req *http.Request) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reqs = append(r.reqs, recordedRequest{
+		Method: req.Method,
+		Path:   req.URL.Path,
+		Query:  req.URL.RawQuery,
+		Auth:   req.Header.Get("Authorization"),
+	})
+}
+
+func (r *ascRecorder) all() []recordedRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]recordedRequest, len(r.reqs))
+	copy(out, r.reqs)
+	return out
+}
+
+// newListAppsServer serves the given JSON bodies in order, one per
+// request, and records every request it receives.
+func newListAppsServer(t *testing.T, status int, bodies ...string) (*httptest.Server, *ascRecorder) {
+	t.Helper()
+	rec := &ascRecorder{}
+	var n int
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r)
+		mu.Lock()
+		i := n
+		n++
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if status != http.StatusOK || i >= len(bodies) {
+			return
+		}
+		_, _ = w.Write([]byte(bodies[i]))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, rec
+}
+
+func newListAppsClient(t *testing.T, baseURL string) *apple.Client {
+	t.Helper()
+	p8 := genP8(t)
+	cli, err := apple.New(apple.Config{
+		BaseURL: baseURL,
+		CredsFetcher: func(context.Context) (apple.Credentials, error) {
+			return apple.Credentials{P8: p8, IssuerID: "iss", KeyID: "kid"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return cli
+}
+
+// assertReadOnly fails if the client sent anything other than a GET —
+// discovery must never mutate state at Apple.
+func assertReadOnly(t *testing.T, reqs []recordedRequest) {
+	t.Helper()
+	if len(reqs) == 0 {
+		t.Fatal("no requests recorded; want at least one GET")
+	}
+	for i, r := range reqs {
+		if r.Method != http.MethodGet {
+			t.Errorf("request %d method = %s, want GET (ListApps must not mutate)", i, r.Method)
+		}
+		if !strings.HasPrefix(r.Auth, "Bearer ") {
+			t.Errorf("request %d Authorization = %q, want Bearer <jwt>", i, r.Auth)
+		}
+	}
+}
+
+const twoAppsBody = `{
+  "data": [
+    {"type":"apps","id":"1111","attributes":{"bundleId":"com.merchant.one","name":"One"}},
+    {"type":"apps","id":"2222","attributes":{"bundleId":"com.merchant.two","name":"Two"}}
+  ],
+  "links": {"self": "https://example.invalid/v1/apps"}
+}`
+
+func TestClient_ListApps_MultipleApps(t *testing.T) {
+	srv, rec := newListAppsServer(t, http.StatusOK, twoAppsBody)
+	cli := newListAppsClient(t, srv.URL)
+
+	apps, err := cli.ListApps(context.Background())
+	if err != nil {
+		t.Fatalf("ListApps: %v", err)
+	}
+
+	reqs := rec.all()
+	assertReadOnly(t, reqs)
+	if reqs[0].Path != "/v1/apps" {
+		t.Errorf("path = %s, want /v1/apps", reqs[0].Path)
+	}
+	if !strings.Contains(reqs[0].Query, "limit=") {
+		t.Errorf("query = %q, want a limit param", reqs[0].Query)
+	}
+
+	if len(apps) != 2 {
+		t.Fatalf("len(apps) = %d, want 2", len(apps))
+	}
+	if apps[0].ID != "1111" || apps[0].BundleID != "com.merchant.one" || apps[0].Name != "One" {
+		t.Errorf("apps[0] = %+v, want id 1111 / com.merchant.one / One", apps[0])
+	}
+	if apps[1].ID != "2222" || apps[1].BundleID != "com.merchant.two" {
+		t.Errorf("apps[1] = %+v, want id 2222 / com.merchant.two", apps[1])
+	}
+}
+
+func TestClient_ListApps_SingleApp(t *testing.T) {
+	body := `{"data":[{"type":"apps","id":"9999","attributes":{"bundleId":"com.merchant.only","name":"Only"}}]}`
+	srv, rec := newListAppsServer(t, http.StatusOK, body)
+	cli := newListAppsClient(t, srv.URL)
+
+	apps, err := cli.ListApps(context.Background())
+	if err != nil {
+		t.Fatalf("ListApps: %v", err)
+	}
+	assertReadOnly(t, rec.all())
+	if len(apps) != 1 {
+		t.Fatalf("len(apps) = %d, want 1", len(apps))
+	}
+	if apps[0].ID != "9999" {
+		t.Errorf("apps[0].ID = %q, want 9999", apps[0].ID)
+	}
+}
+
+// An account with no apps is a fact, not an error — the caller must be
+// able to tell it apart from a rejected key.
+func TestClient_ListApps_EmptyData(t *testing.T) {
+	srv, rec := newListAppsServer(t, http.StatusOK, `{"data":[]}`)
+	cli := newListAppsClient(t, srv.URL)
+
+	apps, err := cli.ListApps(context.Background())
+	if err != nil {
+		t.Fatalf("ListApps on empty data = %v, want nil error", err)
+	}
+	assertReadOnly(t, rec.all())
+	if len(apps) != 0 {
+		t.Errorf("len(apps) = %d, want 0", len(apps))
+	}
+}
+
+func TestClient_ListApps_Unauthorized(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(fmt.Sprint(status), func(t *testing.T) {
+			srv, rec := newListAppsServer(t, status)
+			cli := newListAppsClient(t, srv.URL)
+
+			apps, err := cli.ListApps(context.Background())
+			if !errors.Is(err, apple.ErrUnauthorized) {
+				t.Fatalf("err = %v, want wraps ErrUnauthorized", err)
+			}
+			if apps != nil {
+				t.Errorf("apps = %+v, want nil on error", apps)
+			}
+			assertReadOnly(t, rec.all())
+		})
+	}
+}
+
+// A 500 is not the same fact as a revoked key, and neither is an empty
+// list: the error must surface and must not masquerade as either.
+func TestClient_ListApps_ServerError(t *testing.T) {
+	srv, rec := newListAppsServer(t, http.StatusInternalServerError)
+	cli := newListAppsClient(t, srv.URL)
+
+	apps, err := cli.ListApps(context.Background())
+	if err == nil {
+		t.Fatal("ListApps on 500 = nil error, want error")
+	}
+	if errors.Is(err, apple.ErrUnauthorized) {
+		t.Errorf("err = %v, want a plain error, not ErrUnauthorized", err)
+	}
+	if apps != nil {
+		t.Errorf("apps = %+v, want nil on error", apps)
+	}
+	assertReadOnly(t, rec.all())
+}
+
+// A 404 must NOT be swallowed here. call() maps 404 to success for the
+// idempotent write paths; a read that did the same would report "no
+// apps" for an endpoint it never actually read.
+func TestClient_ListApps_NotFoundIsAnError(t *testing.T) {
+	srv, _ := newListAppsServer(t, http.StatusNotFound)
+	cli := newListAppsClient(t, srv.URL)
+
+	if _, err := cli.ListApps(context.Background()); err == nil {
+		t.Error("ListApps on 404 = nil error, want error (404 is not an empty account)")
+	}
+}
+
+func TestClient_ListApps_MalformedJSON(t *testing.T) {
+	srv, _ := newListAppsServer(t, http.StatusOK, `{"data": [`)
+	cli := newListAppsClient(t, srv.URL)
+
+	if _, err := cli.ListApps(context.Background()); err == nil {
+		t.Error("ListApps on malformed body = nil error, want error")
+	}
+}
+
+func TestClient_ListApps_FollowsNextLink(t *testing.T) {
+	rec := &ascRecorder{}
+	var mu sync.Mutex
+	var n int
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r)
+		mu.Lock()
+		i := n
+		n++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		if i == 0 {
+			fmt.Fprintf(w, `{"data":[{"id":"p1","attributes":{"bundleId":"com.a","name":"A"}}],"links":{"next":"%s/v1/apps?cursor=abc"}}`, srv.URL)
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":[{"id":"p2","attributes":{"bundleId":"com.b","name":"B"}}]}`))
+	}))
+	defer srv.Close()
+
+	cli := newListAppsClient(t, srv.URL)
+	apps, err := cli.ListApps(context.Background())
+	if err != nil {
+		t.Fatalf("ListApps: %v", err)
+	}
+
+	reqs := rec.all()
+	assertReadOnly(t, reqs)
+	if len(reqs) != 2 {
+		t.Fatalf("requests = %d, want 2 (first page + links.next)", len(reqs))
+	}
+	if !strings.Contains(reqs[1].Query, "cursor=abc") {
+		t.Errorf("second request query = %q, want cursor=abc from links.next", reqs[1].Query)
+	}
+	if len(apps) != 2 || apps[0].ID != "p1" || apps[1].ID != "p2" {
+		t.Errorf("apps = %+v, want both pages concatenated", apps)
+	}
+}
+
+// links.next pointing off-host must be refused: the Bearer token rides
+// on every hop.
+func TestClient_ListApps_RefusesOffHostNextLink(t *testing.T) {
+	body := `{"data":[],"links":{"next":"https://attacker.invalid/v1/apps"}}`
+	srv, _ := newListAppsServer(t, http.StatusOK, body)
+	cli := newListAppsClient(t, srv.URL)
+
+	if _, err := cli.ListApps(context.Background()); err == nil {
+		t.Error("ListApps with off-host links.next = nil error, want refusal")
+	}
+}
+
+// A links.next that never terminates must hit the documented cap rather
+// than page forever.
+func TestClient_ListApps_PageCap(t *testing.T) {
+	var srv *httptest.Server
+	rec := &ascRecorder{}
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{"data":[{"id":"x","attributes":{}}],"links":{"next":"%s/v1/apps?cursor=loop"}}`, srv.URL)
+	}))
+	defer srv.Close()
+
+	cli := newListAppsClient(t, srv.URL)
+	apps, err := cli.ListApps(context.Background())
+	if !errors.Is(err, apple.ErrTooManyAppPages) {
+		t.Fatalf("err = %v, want wraps ErrTooManyAppPages", err)
+	}
+	if apps != nil {
+		t.Errorf("apps = %+v, want nil rather than a truncated list", apps)
+	}
+	assertReadOnly(t, rec.all())
+}
+
+func TestClient_ListApps_CredsFailureSurfaces(t *testing.T) {
+	sentinel := errors.New("creds read failed")
+	cli, err := apple.New(apple.Config{
+		BaseURL: "https://example.invalid",
+		CredsFetcher: func(context.Context) (apple.Credentials, error) {
+			return apple.Credentials{}, sentinel
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := cli.ListApps(context.Background()); !errors.Is(err, sentinel) {
+		t.Errorf("err = %v, want wraps the creds sentinel", err)
+	}
+}
+
+func TestFakeClient_ListApps(t *testing.T) {
+	f := apple.NewFakeClient()
+	f.Apps = []apple.App{{ID: "a1", BundleID: "com.a"}, {ID: "a2", BundleID: "com.b"}}
+
+	apps, err := f.ListApps(context.Background())
+	if err != nil {
+		t.Fatalf("ListApps: %v", err)
+	}
+	if len(apps) != 2 || apps[0].ID != "a1" {
+		t.Errorf("apps = %+v, want the two configured apps", apps)
+	}
+	if f.ListAppsCallCount != 1 {
+		t.Errorf("ListAppsCallCount = %d, want 1", f.ListAppsCallCount)
+	}
+
+	// Returned slice is a copy — mutating it must not touch the fake.
+	apps[0].ID = "mutated"
+	if f.Apps[0].ID != "a1" {
+		t.Errorf("f.Apps[0].ID = %q, want a1 (ListApps must return a copy)", f.Apps[0].ID)
+	}
+
+	f.ListAppsErr = errors.New("boom")
+	if _, err := f.ListApps(context.Background()); err == nil {
+		t.Error("ListApps with ListAppsErr = nil error, want the configured error")
+	}
+}
+
+// FakeClient must satisfy ClientAPI including the new method.
+var _ apple.ClientAPI = (*apple.FakeClient)(nil)
+var _ apple.ClientAPI = (*apple.Client)(nil)

--- a/services/marketplace-api/internal/whitelabel/lifecycle/advancer.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/advancer.go
@@ -279,6 +279,46 @@ func (a *Advancer) archiveFirebase(ctx context.Context, r Row) error {
 	if err := a.firebase.ArchiveProject(ctx, r.FirebaseProjectID); err != nil {
 		a.logger.WarnContext(ctx, "lifecycle: firebase archive skipped",
 			"store_id", r.StoreID, "err", err)
+		// The row is about to transition to `firebase_archived`, and that
+		// status would otherwise be the ONLY durable record of this step —
+		// asserting an archive that did not happen. The status cannot say
+		// so: it is a fixed value the state machine reads to reach day 90,
+		// and erroring here instead would stall every row forever, because
+		// the Firebase client is an unimplemented stub that always returns
+		// ErrNotWired. So the truth goes beside the status rather than in
+		// it. tesserix-home#702's whole subject is a system reporting work
+		// it did not do; a status this code KNOWS is untrue must not be
+		// left as the only thing written down.
+		if noteErr := a.appendNote(ctx, r, StatusFirebaseArchived,
+			fmt.Sprintf("firebase archive NOT performed for project %s: %v", r.FirebaseProjectID, err),
+		); noteErr != nil {
+			// Deliberately not fatal: failing the advance here would stall
+			// the row on a bookkeeping write, and the WARN above has
+			// already been emitted.
+			a.logger.WarnContext(ctx, "lifecycle: could not record firebase skip",
+				"store_id", r.StoreID, "err", noteErr)
+		}
+	}
+	return nil
+}
+
+// appendNote writes a lifecycle row carrying a REASON rather than marking a
+// transition. Same append-only table as appendLog, deliberately: a reader
+// asking "what happened to this store" gets one ordered history, not a
+// status trail plus a separate place the caveats live.
+func (a *Advancer) appendNote(ctx context.Context, r Row, status Status, reason string) error {
+	now := a.clock()
+	entry := subscription.WhiteLabelAppLifecycleEntry{
+		ID:          uuid.New(),
+		StoreID:     r.StoreID,
+		TenantID:    r.TenantID,
+		Status:      status,
+		ScheduledAt: &now,
+		Actor:       "system:cron:lifecycle",
+		Reason:      &reason,
+	}
+	if err := a.db.WithContext(ctx).Create(&entry).Error; err != nil {
+		return fmt.Errorf("lifecycle: append note: %w", err)
 	}
 	return nil
 }

--- a/services/marketplace-api/internal/whitelabel/lifecycle/advancer.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/advancer.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/mark8ly/marketplace-api/internal/billing/appcreds"
 	"github.com/mark8ly/marketplace-api/internal/subscription"
-	"github.com/mark8ly/marketplace-api/internal/whitelabel/apple"
 	"github.com/mark8ly/marketplace-api/internal/whitelabel/firebase"
 	"github.com/mark8ly/marketplace-api/internal/whitelabel/googleplay"
 	wlmetrics "github.com/mark8ly/marketplace-api/internal/whitelabel/metrics"
@@ -23,10 +22,16 @@ type Clock func() time.Time
 
 // Config groups Advancer dependencies. All fields required in
 // production; tests inject fakes for Apple/Google/Firebase.
+//
+// Apple and Google are FACTORIES, not clients: their credentials are
+// per-tenant and the advancer walks a multi-tenant cohort, so a client is
+// resolved per row. See AppleTeardownFactory for why one shared client
+// cannot work. Firebase is a plain client — its stub takes no per-tenant
+// configuration.
 type Config struct {
 	DB       *gorm.DB
-	Apple    apple.ClientAPI
-	Google   googleplay.ClientAPI
+	Apple    AppleTeardownFactory
+	Google   GoogleTeardownFactory
 	Firebase firebase.ClientAPI
 	Creds    *appcreds.Service
 	Clock    Clock // defaults to time.Now when nil
@@ -39,8 +44,8 @@ type Config struct {
 // pullApps / archiveFirebase / purgeCredentials).
 type Advancer struct {
 	db       *gorm.DB
-	apple    apple.ClientAPI
-	google   googleplay.ClientAPI
+	apple    AppleTeardownFactory
+	google   GoogleTeardownFactory
 	firebase firebase.ClientAPI
 	creds    *appcreds.Service
 	clock    Clock
@@ -166,12 +171,22 @@ func (a *Advancer) advanceOne(ctx context.Context, r Row, now time.Time) error {
 // no-op.
 func (a *Advancer) blockDownloads(ctx context.Context, r Row) error {
 	if r.AppleAppID != "" {
-		if err := a.apple.BlockDownloads(ctx, r.AppleAppID); err != nil {
+		cli, err := a.appleClient(ctx, r)
+		if err != nil {
+			return err
+		}
+		if err := cli.BlockDownloads(ctx, r.AppleAppID); err != nil {
 			return fmt.Errorf("apple.BlockDownloads(%s): %w", r.AppleAppID, err)
 		}
 	}
 	if r.GooglePackage != "" {
-		if err := a.google.BlockDownloads(ctx, r.GooglePackage); err != nil {
+		cli, err := a.googleClient(ctx, r)
+		if err != nil {
+			a.logger.WarnContext(ctx, "lifecycle: google client unavailable; block downloads skipped",
+				"store_id", r.StoreID, "err", err)
+			return nil
+		}
+		if err := cli.BlockDownloads(ctx, r.GooglePackage); err != nil {
 			// Google's ErrNotWired is tolerated — it means Apple was
 			// successful and Google integration is deferred. Logged
 			// and swallowed rather than stalling the advance.
@@ -184,17 +199,77 @@ func (a *Advancer) blockDownloads(ctx context.Context, r Row) error {
 
 func (a *Advancer) pullApps(ctx context.Context, r Row) error {
 	if r.AppleAppID != "" {
-		if err := a.apple.PullApp(ctx, r.AppleAppID); err != nil {
+		cli, err := a.appleClient(ctx, r)
+		if err != nil {
+			return err
+		}
+		if err := cli.PullApp(ctx, r.AppleAppID); err != nil {
 			return fmt.Errorf("apple.PullApp(%s): %w", r.AppleAppID, err)
 		}
 	}
 	if r.GooglePackage != "" {
-		if err := a.google.PullApp(ctx, r.GooglePackage); err != nil {
+		cli, err := a.googleClient(ctx, r)
+		if err != nil {
+			a.logger.WarnContext(ctx, "lifecycle: google client unavailable; pull app skipped",
+				"store_id", r.StoreID, "err", err)
+			return nil
+		}
+		if err := cli.PullApp(ctx, r.GooglePackage); err != nil {
 			a.logger.WarnContext(ctx, "lifecycle: google pull app skipped",
 				"store_id", r.StoreID, "err", err)
 		}
 	}
 	return nil
+}
+
+// appleClient resolves the App Store Connect client for one row's tenant.
+//
+// A resolution failure — no factory wired, credentials revoked, the store's
+// ASC key already purged — is returned as an ERROR, which stalls the row:
+// advanceOne aborts, no status is written and no lifecycle log row is
+// appended, so next_action_at stays due and the step retries next tick.
+//
+// It is deliberately NOT "log it and mark the step done". A row whose
+// merchant we cannot authenticate as has not had its listing blocked or
+// pulled; advancing it would write downloads_blocked or pulled into the
+// append-only audit table asserting a teardown that never happened, which
+// is the exact failure #702 exists to fix. A row stuck retrying with an
+// ERROR log every tick is a visible, truthful state; a row that walked to
+// credentials_purged having touched nothing is not.
+func (a *Advancer) appleClient(ctx context.Context, r Row) (AppleTeardownClient, error) {
+	if a.apple == nil {
+		return nil, fmt.Errorf("lifecycle: no Apple client factory configured (store %s carries apple app id %s)",
+			r.StoreID, r.AppleAppID)
+	}
+	cli, err := a.apple(ctx, r.TenantID, r.StoreID)
+	if err != nil {
+		return nil, fmt.Errorf("lifecycle: apple client for store %s: %w", r.StoreID, err)
+	}
+	if cli == nil {
+		return nil, fmt.Errorf("lifecycle: apple client factory returned no client for store %s", r.StoreID)
+	}
+	return cli, nil
+}
+
+// googleClient resolves the Play client for one row's tenant.
+//
+// Unlike appleClient, a failure here is tolerated by the callers: Play
+// teardown is deferred (the client is a stub returning ErrNotWired) and
+// rows carry no GooglePackage by design (#702 decision 4), so this path is
+// unreached today. The asymmetry is deliberate — Apple stalls, Play warns.
+func (a *Advancer) googleClient(ctx context.Context, r Row) (googleplay.ClientAPI, error) {
+	if a.google == nil {
+		return nil, fmt.Errorf("lifecycle: no Google client factory configured (store %s carries package %s)",
+			r.StoreID, r.GooglePackage)
+	}
+	cli, err := a.google(ctx, r.TenantID, r.StoreID)
+	if err != nil {
+		return nil, fmt.Errorf("lifecycle: google client for store %s: %w", r.StoreID, err)
+	}
+	if cli == nil {
+		return nil, fmt.Errorf("lifecycle: google client factory returned no client for store %s", r.StoreID)
+	}
+	return cli, nil
 }
 
 func (a *Advancer) archiveFirebase(ctx context.Context, r Row) error {

--- a/services/marketplace-api/internal/whitelabel/lifecycle/advancer_integration_test.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/advancer_integration_test.go
@@ -4,12 +4,14 @@ package lifecycle_test
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 
 	"github.com/mark8ly/marketplace-api/internal/audit"
 	"github.com/mark8ly/marketplace-api/internal/billing/appcreds"
@@ -48,11 +50,38 @@ func newAdvancer(t *testing.T, fakes struct {
 	t.Helper()
 	db := testdb.NewDB(t, "white_label_app_state", "white_label_app_lifecycle")
 	return lifecycle.NewAdvancer(lifecycle.Config{
-		DB: db, Apple: fakes.Apple, Google: fakes.Google,
+		DB:       db,
+		Apple:    staticAppleFactory(fakes.Apple),
+		Google:   staticGoogleFactory(fakes.Google),
 		Firebase: fakes.Firebase, Creds: fakes.Creds,
 		Clock:  func() time.Time { return time.Now().UTC() },
 		Logger: slog.Default(),
 	})
+}
+
+// staticAppleFactory adapts a single fake to the per-tenant factory the
+// advancer now takes. Production resolves a different client per row from
+// that row's stored credentials; a test cohort is one tenant, so handing
+// back the same fake preserves exactly the call-count assertions the
+// pre-factory tests made.
+func staticAppleFactory(c lifecycle.AppleTeardownClient) lifecycle.AppleTeardownFactory {
+	return func(context.Context, uuid.UUID, uuid.UUID) (lifecycle.AppleTeardownClient, error) {
+		return c, nil
+	}
+}
+
+func staticGoogleFactory(c googleplay.ClientAPI) lifecycle.GoogleTeardownFactory {
+	return func(context.Context, uuid.UUID, uuid.UUID) (googleplay.ClientAPI, error) {
+		return c, nil
+	}
+}
+
+// failingAppleFactory stands in for credentials that have been revoked,
+// or a store whose ASC key is already gone.
+func failingAppleFactory(err error) lifecycle.AppleTeardownFactory {
+	return func(context.Context, uuid.UUID, uuid.UUID) (lifecycle.AppleTeardownClient, error) {
+		return nil, err
+	}
 }
 
 func newCredsSvc(t *testing.T) (*appcreds.Service, *appcreds.FakeSM) {
@@ -210,4 +239,130 @@ func TestAdvancer_TerminalRow_NotRepicked(t *testing.T) {
 	require.NoError(t, adv.AdvanceDue(context.Background()))
 	require.Equal(t, 0, appleCli.BlockDownloadsCallCount)
 	require.Equal(t, 0, fbCli.DeleteProjectCallCount)
+}
+
+// ─── Factory-resolution failures ─────────────────────────────────────
+
+// newAdvancerWithFactories is newAdvancer with the client factories
+// supplied directly, for the resolution-failure cases.
+func newAdvancerWithFactories(
+	t *testing.T,
+	db *gorm.DB,
+	appleF lifecycle.AppleTeardownFactory,
+	googleF lifecycle.GoogleTeardownFactory,
+	fbCli *firebase.FakeClient,
+	creds *appcreds.Service,
+) *lifecycle.Advancer {
+	t.Helper()
+	return lifecycle.NewAdvancer(lifecycle.Config{
+		DB: db, Apple: appleF, Google: googleF,
+		Firebase: fbCli, Creds: creds,
+		Clock:  func() time.Time { return time.Now().UTC() },
+		Logger: slog.Default(),
+	})
+}
+
+// TestAdvancer_Day30_AppleClientUnresolvable_DoesNotAdvance is the point
+// of #702 in one test: a row whose merchant we cannot authenticate as has
+// NOT had its downloads blocked, so it must not be recorded as though it
+// had. The status stays sunset_scheduled, next_action_at stays due (so the
+// step retries), and no lifecycle log row is appended.
+func TestAdvancer_Day30_AppleClientUnresolvable_DoesNotAdvance(t *testing.T) {
+	creds, _ := newCredsSvc(t)
+	fbCli := firebase.NewFakeClient()
+	db := testdb.NewDB(t, "white_label_app_state", "white_label_app_lifecycle")
+	adv := newAdvancerWithFactories(t, db,
+		failingAppleFactory(errors.New("appcreds: apple-asc-api-key not found")),
+		staticGoogleFactory(googleplay.NewFakeClient()), fbCli, creds)
+
+	row := ageRow(t, 30, lifecycle.StatusSunsetScheduled)
+	dueBefore := *row.NextActionAt
+	require.NoError(t, db.Create(&row).Error)
+
+	// AdvanceDue logs and skips the row; the cohort-level call succeeds.
+	require.NoError(t, adv.AdvanceDue(context.Background()))
+
+	var after lifecycle.Row
+	require.NoError(t, db.Where("id=?", row.ID).First(&after).Error)
+	require.Equal(t, lifecycle.StatusSunsetScheduled, after.Status,
+		"an unreachable Apple account must not advance to downloads_blocked")
+	require.NotNil(t, after.NextActionAt)
+	require.WithinDuration(t, dueBefore, *after.NextActionAt, time.Second,
+		"next_action_at must stay due so the step retries next tick")
+
+	var logCount int64
+	require.NoError(t, db.Model(&subscription.WhiteLabelAppLifecycleEntry{}).
+		Where("store_id=?", row.StoreID).Count(&logCount).Error)
+	require.Equal(t, int64(0), logCount,
+		"no audit row may claim a teardown step that never reached Apple")
+}
+
+// TestAdvancer_Day60_AppleClientUnresolvable_DoesNotAdvance is the same
+// guarantee at the pull step, which is the more damaging one to fake: it
+// writes `pulled` against a listing still live in the App Store.
+func TestAdvancer_Day60_AppleClientUnresolvable_DoesNotAdvance(t *testing.T) {
+	creds, _ := newCredsSvc(t)
+	fbCli := firebase.NewFakeClient()
+	db := testdb.NewDB(t, "white_label_app_state", "white_label_app_lifecycle")
+	adv := newAdvancerWithFactories(t, db,
+		failingAppleFactory(errors.New("appcreds: apple-asc-api-key not found")),
+		staticGoogleFactory(googleplay.NewFakeClient()), fbCli, creds)
+
+	row := ageRow(t, 60, lifecycle.StatusDownloadsBlocked)
+	require.NoError(t, db.Create(&row).Error)
+
+	require.NoError(t, adv.AdvanceDue(context.Background()))
+
+	var after lifecycle.Row
+	require.NoError(t, db.Where("id=?", row.ID).First(&after).Error)
+	require.Equal(t, lifecycle.StatusDownloadsBlocked, after.Status,
+		"an unreachable Apple account must not advance to pulled")
+	require.Equal(t, 0, fbCli.ArchiveProjectCalls,
+		"the firebase archive that follows pulled must not run either")
+}
+
+// TestAdvancer_Day30_NilAppleFactory_DoesNotAdvance covers the wiring
+// mistake rather than the runtime one: a Config with no Apple factory at
+// all must stall the row, not treat "nothing to call" as success.
+func TestAdvancer_Day30_NilAppleFactory_DoesNotAdvance(t *testing.T) {
+	creds, _ := newCredsSvc(t)
+	db := testdb.NewDB(t, "white_label_app_state", "white_label_app_lifecycle")
+	adv := newAdvancerWithFactories(t, db, nil,
+		staticGoogleFactory(googleplay.NewFakeClient()), firebase.NewFakeClient(), creds)
+
+	row := ageRow(t, 30, lifecycle.StatusSunsetScheduled)
+	require.NoError(t, db.Create(&row).Error)
+
+	require.NoError(t, adv.AdvanceDue(context.Background()))
+
+	var after lifecycle.Row
+	require.NoError(t, db.Where("id=?", row.ID).First(&after).Error)
+	require.Equal(t, lifecycle.StatusSunsetScheduled, after.Status)
+}
+
+// TestAdvancer_Day30_GoogleClientUnresolvable_StillAdvances pins the
+// deliberate asymmetry: Play teardown is deferred, so a Play failure is
+// warned and swallowed, while the identical Apple failure stalls the row.
+// If this ever starts stalling, Play has silently become load-bearing.
+func TestAdvancer_Day30_GoogleClientUnresolvable_StillAdvances(t *testing.T) {
+	creds, _ := newCredsSvc(t)
+	appleCli := apple.NewFakeClient()
+	db := testdb.NewDB(t, "white_label_app_state", "white_label_app_lifecycle")
+	adv := newAdvancerWithFactories(t, db,
+		staticAppleFactory(appleCli),
+		func(context.Context, uuid.UUID, uuid.UUID) (googleplay.ClientAPI, error) {
+			return nil, errors.New("appcreds: google-play-service-account not found")
+		},
+		firebase.NewFakeClient(), creds)
+
+	row := ageRow(t, 30, lifecycle.StatusSunsetScheduled)
+	require.NoError(t, db.Create(&row).Error)
+
+	require.NoError(t, adv.AdvanceDue(context.Background()))
+
+	var after lifecycle.Row
+	require.NoError(t, db.Where("id=?", row.ID).First(&after).Error)
+	require.Equal(t, lifecycle.StatusDownloadsBlocked, after.Status,
+		"a Play failure is tolerated; Apple is what makes the step real")
+	require.Equal(t, 1, appleCli.BlockDownloadsCallCount)
 }

--- a/services/marketplace-api/internal/whitelabel/lifecycle/advancer_integration_test.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/advancer_integration_test.go
@@ -366,3 +366,47 @@ func TestAdvancer_Day30_GoogleClientUnresolvable_StillAdvances(t *testing.T) {
 		"a Play failure is tolerated; Apple is what makes the step real")
 	require.Equal(t, 1, appleCli.BlockDownloadsCallCount)
 }
+
+// A Firebase archive that did not happen must be written down, because the
+// row is about to claim `firebase_archived` and that status cannot say
+// otherwise — it is a fixed value the state machine reads to reach day 90.
+// The real Firebase client is an unimplemented stub that always returns
+// ErrNotWired, so without this the ONLY durable record of the step asserts
+// an archive that never occurred. tesserix-home#702 is precisely about a
+// system reporting work it did not do.
+func TestAdvancer_FirebaseArchiveFailure_IsRecordedBesideTheStatus(t *testing.T) {
+	creds, _ := newCredsSvc(t)
+	appleCli, gpCli, fbCli := apple.NewFakeClient(), googleplay.NewFakeClient(), firebase.NewFakeClient()
+	fbCli.ArchiveErr = firebase.ErrNotWired
+	adv := newAdvancer(t, struct {
+		Apple    *apple.FakeClient
+		Google   *googleplay.FakeClient
+		Firebase *firebase.FakeClient
+		Creds    *appcreds.Service
+	}{appleCli, gpCli, fbCli, creds})
+
+	db := testdb.NewDB(t, "white_label_app_state", "white_label_app_lifecycle")
+	// StatusPulled, not DownloadsBlocked: day 60 transitions INTO Pulled,
+	// and `archiveFirebase` runs on the Pulled case on the following tick.
+	row := ageRow(t, 60, lifecycle.StatusPulled)
+	row.FirebaseProjectID = "merchant-proj-1"
+	require.NoError(t, db.Create(&row).Error)
+
+	require.NoError(t, adv.AdvanceDue(context.Background()))
+
+	// The row still advances — erroring here would stall every row forever,
+	// since the stub never succeeds, and would block the day-90 purge.
+	var after lifecycle.Row
+	require.NoError(t, db.Where("id=?", row.ID).First(&after).Error)
+	require.Equal(t, lifecycle.StatusFirebaseArchived, after.Status)
+
+	// …but the failure is durable, with a reason naming the project.
+	var reasons []string
+	require.NoError(t, db.Raw(
+		`SELECT reason FROM white_label_app_lifecycle
+		  WHERE store_id = ? AND reason IS NOT NULL`, row.StoreID,
+	).Scan(&reasons).Error)
+	require.NotEmpty(t, reasons, "a skipped firebase archive must leave a reason behind")
+	require.Contains(t, reasons[0], "NOT performed")
+	require.Contains(t, reasons[0], "merchant-proj-1")
+}

--- a/services/marketplace-api/internal/whitelabel/lifecycle/client_factory.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/client_factory.go
@@ -1,0 +1,138 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/appcreds"
+	"github.com/mark8ly/marketplace-api/internal/whitelabel/apple"
+	"github.com/mark8ly/marketplace-api/internal/whitelabel/googleplay"
+)
+
+// teardownActor is the audit actor recorded against every credential read
+// the ADVANCER performs, distinct from discoveryActor so the day-30/60
+// writes are separable in the credential-access audit stream from the
+// day-of-cancellation discovery reads (#702).
+const teardownActor = "system:cron:lifecycle_teardown"
+
+// AppleTeardownClient is the write slice of apple.ClientAPI the advancer
+// needs, at day 30 and day 60. Narrow for the same reason AppleLister is
+// narrow in the other direction: discovery may only read, teardown may
+// only write, and neither can reach the other's verbs by accident.
+type AppleTeardownClient interface {
+	BlockDownloads(ctx context.Context, appleAppID string) error
+	PullApp(ctx context.Context, appleAppID string) error
+}
+
+// AppleTeardownFactory returns a teardown client authenticated as one
+// tenant.
+//
+// PER ROW, not per process. apple.Client's CredsFetcher is
+// func(ctx) (Credentials, error) — it takes no tenant — so a constructed
+// client carries exactly one merchant's App Store Connect key. The
+// advancer walks a cohort spanning many tenants, so one shared client
+// cannot serve it: it would sign every merchant's teardown with whichever
+// key it happened to be built with, and either fail or, worse, act on
+// somebody else's account.
+type AppleTeardownFactory func(ctx context.Context, tenantID, storeID uuid.UUID) (AppleTeardownClient, error)
+
+// GoogleTeardownFactory is the Play equivalent. Play has the same
+// structural constraint as Apple — googleplay.Client's CredsFetcher is
+// also tenant-less — so "wire the real client instead of the fake" is not
+// a one-line swap on this side either.
+//
+// The real client returns googleplay.ErrNotWired from every method, after
+// fetching credentials. That is what production should see: an honest
+// "not implemented", rather than googleplay.FakeClient's silent success.
+type GoogleTeardownFactory func(ctx context.Context, tenantID, storeID uuid.UUID) (googleplay.ClientAPI, error)
+
+// NewAppleTeardownFactory builds a real App Store Connect client per
+// tenant from that tenant's stored .p8 key, issuer id and key id.
+func NewAppleTeardownFactory(creds CredentialLoader) AppleTeardownFactory {
+	return func(_ context.Context, tenantID, storeID uuid.UUID) (AppleTeardownClient, error) {
+		client, err := newAppleClient(creds, tenantID, storeID, teardownActor)
+		if err != nil {
+			// Untyped nil: a typed-nil *apple.Client behind a non-nil
+			// interface would pass a `!= nil` check and panic later
+			// (#288's shape).
+			return nil, err
+		}
+		return client, nil
+	}
+}
+
+// NewGoogleTeardownFactory builds a real Android Publisher client per
+// tenant from that tenant's stored service-account JSON.
+func NewGoogleTeardownFactory(creds CredentialLoader) GoogleTeardownFactory {
+	return func(_ context.Context, tenantID, storeID uuid.UUID) (googleplay.ClientAPI, error) {
+		if creds == nil {
+			return nil, errors.New("lifecycle: appcreds service is nil")
+		}
+		client, err := googleplay.New(googleplay.Config{
+			CredsFetcher: func(ctx context.Context) (googleplay.Credentials, error) {
+				payload, err := creds.Load(ctx, appcreds.LoadInput{
+					TenantID: tenantID,
+					StoreID:  storeID,
+					CredType: appcreds.CredTypeGooglePlayJSON,
+					Actor:    teardownActor,
+				})
+				if err != nil {
+					return googleplay.Credentials{}, fmt.Errorf("load %s: %w", appcreds.CredTypeGooglePlayJSON, err)
+				}
+				return googleplay.Credentials{ServiceAccountJSON: payload}, nil
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		return client, nil
+	}
+}
+
+// newAppleClient is the single place an authenticated *apple.Client is
+// built, shared by discovery's read-only factory and the advancer's
+// teardown factory so the two cannot drift in how they load credentials.
+//
+// Credentials are fetched inside the CredsFetcher closure — per API call,
+// not once at construction — so a key rotated or revoked between the
+// factory call and the request is picked up, and so every read goes
+// through appcreds' audit + metrics choke point. actor distinguishes
+// which caller asked.
+func newAppleClient(creds CredentialLoader, tenantID, storeID uuid.UUID, actor string) (*apple.Client, error) {
+	if creds == nil {
+		return nil, errors.New("lifecycle: appcreds service is nil")
+	}
+	return apple.New(apple.Config{
+		CredsFetcher: func(ctx context.Context) (apple.Credentials, error) {
+			load := func(ct appcreds.CredType) ([]byte, error) {
+				return creds.Load(ctx, appcreds.LoadInput{
+					TenantID: tenantID,
+					StoreID:  storeID,
+					CredType: ct,
+					Actor:    actor,
+				})
+			}
+			p8, err := load(appcreds.CredTypeAppleP8)
+			if err != nil {
+				return apple.Credentials{}, fmt.Errorf("load %s: %w", appcreds.CredTypeAppleP8, err)
+			}
+			issuer, err := load(appcreds.CredTypeAppleIssuerID)
+			if err != nil {
+				return apple.Credentials{}, fmt.Errorf("load %s: %w", appcreds.CredTypeAppleIssuerID, err)
+			}
+			keyID, err := load(appcreds.CredTypeAppleKeyID)
+			if err != nil {
+				return apple.Credentials{}, fmt.Errorf("load %s: %w", appcreds.CredTypeAppleKeyID, err)
+			}
+			return apple.Credentials{
+				P8:       p8,
+				IssuerID: strings.TrimSpace(string(issuer)),
+				KeyID:    strings.TrimSpace(string(keyID)),
+			}, nil
+		},
+	})
+}

--- a/services/marketplace-api/internal/whitelabel/lifecycle/discovery.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/discovery.go
@@ -188,44 +188,13 @@ func describeApps(apps []apple.App) string {
 // Connect client per tenant, authenticated with that tenant's stored .p8
 // key, issuer id and key id.
 //
-// Credentials are fetched inside the CredsFetcher closure — that is, per
-// API call, not once at factory time — so a key rotated or revoked
-// between the factory call and the request is picked up, and so every
-// read goes through appcreds' audit + metrics choke point.
+// The client itself is built by newAppleClient (client_factory.go), which
+// the advancer's teardown factory shares, so the read path and the write
+// path cannot drift in how they load credentials. Only the audit actor
+// differs — discoveryActor here, teardownActor there.
 func NewAppleListerFactory(creds CredentialLoader) AppleListerFactory {
 	return func(_ context.Context, tenantID, storeID uuid.UUID) (AppleLister, error) {
-		if creds == nil {
-			return nil, errors.New("lifecycle/discovery: appcreds service is nil")
-		}
-		client, err := apple.New(apple.Config{
-			CredsFetcher: func(ctx context.Context) (apple.Credentials, error) {
-				load := func(ct appcreds.CredType) ([]byte, error) {
-					return creds.Load(ctx, appcreds.LoadInput{
-						TenantID: tenantID,
-						StoreID:  storeID,
-						CredType: ct,
-						Actor:    discoveryActor,
-					})
-				}
-				p8, err := load(appcreds.CredTypeAppleP8)
-				if err != nil {
-					return apple.Credentials{}, fmt.Errorf("load %s: %w", appcreds.CredTypeAppleP8, err)
-				}
-				issuer, err := load(appcreds.CredTypeAppleIssuerID)
-				if err != nil {
-					return apple.Credentials{}, fmt.Errorf("load %s: %w", appcreds.CredTypeAppleIssuerID, err)
-				}
-				keyID, err := load(appcreds.CredTypeAppleKeyID)
-				if err != nil {
-					return apple.Credentials{}, fmt.Errorf("load %s: %w", appcreds.CredTypeAppleKeyID, err)
-				}
-				return apple.Credentials{
-					P8:       p8,
-					IssuerID: strings.TrimSpace(string(issuer)),
-					KeyID:    strings.TrimSpace(string(keyID)),
-				}, nil
-			},
-		})
+		client, err := newAppleClient(creds, tenantID, storeID, discoveryActor)
 		if err != nil {
 			// Return an untyped nil: a typed-nil *Client behind a
 			// non-nil AppleLister interface would pass a `!= nil`

--- a/services/marketplace-api/internal/whitelabel/lifecycle/discovery.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/discovery.go
@@ -1,0 +1,237 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/appcreds"
+	"github.com/mark8ly/marketplace-api/internal/whitelabel/apple"
+)
+
+// Discovery resolves the external identifiers a teardown needs from the
+// credentials already stored for a tenant (#702, decision 1: discover,
+// do not record — there is no provisioning flow that writes them down).
+//
+// It runs at CANCEL time rather than lazily at day 30/60/90 (decision 2).
+// The advancer purges every credential type at day 90, so a row that
+// reaches credentials_purged without having discovered anything has
+// permanently lost the ability to: the ASC key it would have asked with
+// is gone. Discovering early costs one read; discovering late is
+// impossible.
+type Discovery struct {
+	// Apple builds a lister bound to one tenant's stored App Store
+	// Connect credentials. Per-tenant because ASC credentials are
+	// per-tenant: there is no single client that can answer for
+	// everybody.
+	Apple AppleListerFactory
+
+	// Creds reads the Google Play service-account JSON, whose
+	// project_id is the only source we have for FirebaseProjectID.
+	Creds CredentialLoader
+
+	Logger *slog.Logger
+}
+
+// AppleLister is the read-only slice of apple.ClientAPI that discovery
+// needs. Narrow on purpose: discovery must not be able to call
+// BlockDownloads or PullApp — those belong to the advancer, at day 30
+// and day 60, not to a cancellation handler.
+type AppleLister interface {
+	ListApps(ctx context.Context) ([]apple.App, error)
+}
+
+// AppleListerFactory returns a lister authenticated as the given tenant.
+type AppleListerFactory func(ctx context.Context, tenantID, storeID uuid.UUID) (AppleLister, error)
+
+// CredentialLoader is the read-only slice of *appcreds.Service that
+// discovery needs. *appcreds.Service satisfies it.
+type CredentialLoader interface {
+	Load(ctx context.Context, in appcreds.LoadInput) ([]byte, error)
+}
+
+// discoveryActor is the audit actor recorded against every credential
+// read discovery performs, so the day-of-cancellation reads are
+// distinguishable in the credential-access audit stream from the
+// advancer's day-90 purge.
+const discoveryActor = "system:cron:pro_app_cancelled_discovery"
+
+// ErrNoAppleApp reports that the store's ASC credentials returned zero
+// apps. Distinct from ErrAmbiguousAppleApp and from apple.ErrUnauthorized
+// on purpose: "the account has no apps", "the account has several" and
+// "the key was rejected so we do not know" are three different facts and
+// only the first two are conclusions about the merchant.
+var ErrNoAppleApp = errors.New("lifecycle/discovery: App Store Connect returned no apps for this store's credentials")
+
+// ErrAmbiguousAppleApp reports that the credentials see more than one
+// app, so there is no single listing this cancellation identifies.
+//
+// This REFUSES rather than picking one (decision 3). Guessing is not a
+// smaller version of the same action: pulling the wrong app id retires a
+// listing belonging to a merchant who did not cancel, which is a worse
+// outcome than retiring nothing and saying so.
+var ErrAmbiguousAppleApp = errors.New("lifecycle/discovery: App Store Connect returned more than one app for this store's credentials")
+
+// ErrDiscoveryNotConfigured reports that ProAppCancelled was called on a
+// consumer with no Discovery attached. Returned rather than silently
+// seeding an empty row.
+var ErrDiscoveryNotConfigured = errors.New("lifecycle/consumer: no Discovery configured; call WithDiscovery before ProAppCancelled")
+
+// discover resolves the identifiers for one store.
+//
+// Apple is required: without an app id there is nothing this teardown can
+// retire, and a row seeded without one would walk the state machine to
+// credentials_purged having touched nothing (see ErrNoAppIdentifiers).
+// Firebase is best-effort — its absence narrows what gets torn down but
+// does not make the row a lie, and the Apple id alone is a real teardown.
+func (d *Discovery) discover(ctx context.Context, tenantID, storeID uuid.UUID) (ProAppCancelledEvent, error) {
+	log := d.logger()
+
+	appleID, err := d.discoverAppleAppID(ctx, tenantID, storeID)
+	if err != nil {
+		return ProAppCancelledEvent{}, err
+	}
+
+	// GooglePackage is deliberately left empty (decision 4): there is no
+	// source for it, and inventing a placeholder to satisfy the
+	// advancer's `if r.GooglePackage != ""` guards would seed a row that
+	// claims an identifier it does not have. The row's Play coverage is
+	// stated explicitly instead — see teardownCoverage.
+	ev := ProAppCancelledEvent{
+		TenantID:          tenantID,
+		StoreID:           storeID,
+		AppleAppID:        appleID,
+		FirebaseProjectID: d.discoverFirebaseProjectID(ctx, tenantID, storeID, log),
+	}
+	return ev, nil
+}
+
+func (d *Discovery) discoverAppleAppID(ctx context.Context, tenantID, storeID uuid.UUID) (string, error) {
+	if d.Apple == nil {
+		return "", errors.New("lifecycle/discovery: no Apple lister factory configured")
+	}
+	lister, err := d.Apple(ctx, tenantID, storeID)
+	if err != nil {
+		return "", fmt.Errorf("lifecycle/discovery: apple client for store %s: %w", storeID, err)
+	}
+	apps, err := lister.ListApps(ctx)
+	if err != nil {
+		return "", fmt.Errorf("lifecycle/discovery: list apps for store %s: %w", storeID, err)
+	}
+	switch len(apps) {
+	case 1:
+		return apps[0].ID, nil
+	case 0:
+		return "", fmt.Errorf("%w (store %s)", ErrNoAppleApp, storeID)
+	default:
+		return "", fmt.Errorf("%w (store %s saw %d: %s)",
+			ErrAmbiguousAppleApp, storeID, len(apps), describeApps(apps))
+	}
+}
+
+// discoverFirebaseProjectID reads the Play service-account JSON and
+// returns its project_id. Failures are logged and yield "" rather than
+// failing the whole discovery: a missing Firebase project makes the
+// teardown narrower, not wrong, and the row states the narrowing.
+func (d *Discovery) discoverFirebaseProjectID(ctx context.Context, tenantID, storeID uuid.UUID, log *slog.Logger) string {
+	if d.Creds == nil {
+		log.WarnContext(ctx, "lifecycle/discovery: no credential loader; firebase project id not discovered",
+			"store_id", storeID)
+		return ""
+	}
+	payload, err := d.Creds.Load(ctx, appcreds.LoadInput{
+		TenantID: tenantID,
+		StoreID:  storeID,
+		CredType: appcreds.CredTypeGooglePlayJSON,
+		Actor:    discoveryActor,
+	})
+	if err != nil {
+		log.WarnContext(ctx, "lifecycle/discovery: google play service account unavailable; firebase project id not discovered",
+			"store_id", storeID, "err", err)
+		return ""
+	}
+	// The project_id is the GCP project owning the service account —
+	// usually, but not necessarily, the Firebase project backing the app.
+	// See appcreds.GooglePlayProjectID for why that is an inference.
+	projectID, err := appcreds.GooglePlayProjectID(payload)
+	if err != nil {
+		log.WarnContext(ctx, "lifecycle/discovery: google play service account is not parseable; firebase project id not discovered",
+			"store_id", storeID, "err", err)
+		return ""
+	}
+	return projectID
+}
+
+func (d *Discovery) logger() *slog.Logger {
+	if d.Logger != nil {
+		return d.Logger
+	}
+	return slog.Default()
+}
+
+// describeApps renders the ambiguous set for the refusal message. An
+// opaque numeric app id alone does not tell an operator which listings
+// the credentials saw, and that is the question they will have.
+func describeApps(apps []apple.App) string {
+	parts := make([]string, 0, len(apps))
+	for _, a := range apps {
+		parts = append(parts, fmt.Sprintf("%s(%s)", a.ID, a.BundleID))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// NewAppleListerFactory returns a factory that builds a real App Store
+// Connect client per tenant, authenticated with that tenant's stored .p8
+// key, issuer id and key id.
+//
+// Credentials are fetched inside the CredsFetcher closure — that is, per
+// API call, not once at factory time — so a key rotated or revoked
+// between the factory call and the request is picked up, and so every
+// read goes through appcreds' audit + metrics choke point.
+func NewAppleListerFactory(creds CredentialLoader) AppleListerFactory {
+	return func(_ context.Context, tenantID, storeID uuid.UUID) (AppleLister, error) {
+		if creds == nil {
+			return nil, errors.New("lifecycle/discovery: appcreds service is nil")
+		}
+		client, err := apple.New(apple.Config{
+			CredsFetcher: func(ctx context.Context) (apple.Credentials, error) {
+				load := func(ct appcreds.CredType) ([]byte, error) {
+					return creds.Load(ctx, appcreds.LoadInput{
+						TenantID: tenantID,
+						StoreID:  storeID,
+						CredType: ct,
+						Actor:    discoveryActor,
+					})
+				}
+				p8, err := load(appcreds.CredTypeAppleP8)
+				if err != nil {
+					return apple.Credentials{}, fmt.Errorf("load %s: %w", appcreds.CredTypeAppleP8, err)
+				}
+				issuer, err := load(appcreds.CredTypeAppleIssuerID)
+				if err != nil {
+					return apple.Credentials{}, fmt.Errorf("load %s: %w", appcreds.CredTypeAppleIssuerID, err)
+				}
+				keyID, err := load(appcreds.CredTypeAppleKeyID)
+				if err != nil {
+					return apple.Credentials{}, fmt.Errorf("load %s: %w", appcreds.CredTypeAppleKeyID, err)
+				}
+				return apple.Credentials{
+					P8:       p8,
+					IssuerID: strings.TrimSpace(string(issuer)),
+					KeyID:    strings.TrimSpace(string(keyID)),
+				}, nil
+			},
+		})
+		if err != nil {
+			// Return an untyped nil: a typed-nil *Client behind a
+			// non-nil AppleLister interface would pass a `!= nil`
+			// check and panic later (#288's shape).
+			return nil, err
+		}
+		return client, nil
+	}
+}

--- a/services/marketplace-api/internal/whitelabel/lifecycle/discovery_test.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/discovery_test.go
@@ -1,0 +1,192 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/billing/appcreds"
+	"github.com/mark8ly/marketplace-api/internal/whitelabel/apple"
+)
+
+// stubCreds returns a fixed payload (or error) for every credential type
+// the discovery path asks for.
+type stubCreds struct {
+	byType map[appcreds.CredType][]byte
+	err    error
+	loaded []appcreds.CredType
+}
+
+func (s *stubCreds) Load(_ context.Context, in appcreds.LoadInput) ([]byte, error) {
+	s.loaded = append(s.loaded, in.CredType)
+	if s.err != nil {
+		return nil, s.err
+	}
+	payload, ok := s.byType[in.CredType]
+	if !ok {
+		return nil, appcreds.ErrNotFound
+	}
+	return payload, nil
+}
+
+const serviceAccountJSON = `{
+  "type": "service_account",
+  "project_id": "merchant-app-42",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----\n",
+  "client_email": "play@merchant-app-42.iam.gserviceaccount.com"
+}`
+
+func discoveryWith(apps []apple.App, listErr error, creds CredentialLoader) *Discovery {
+	fake := apple.NewFakeClient()
+	fake.Apps = apps
+	fake.ListAppsErr = listErr
+	return &Discovery{
+		Apple: func(context.Context, uuid.UUID, uuid.UUID) (AppleLister, error) {
+			return fake, nil
+		},
+		Creds: creds,
+	}
+}
+
+func TestDiscover_ExactlyOneApp_Succeeds(t *testing.T) {
+	d := discoveryWith(
+		[]apple.App{{ID: "6448000111", BundleID: "com.merchant.shop", Name: "Shop"}},
+		nil,
+		&stubCreds{byType: map[appcreds.CredType][]byte{
+			appcreds.CredTypeGooglePlayJSON: []byte(serviceAccountJSON),
+		}},
+	)
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	ev, err := d.discover(context.Background(), tenantID, storeID)
+	require.NoError(t, err)
+	require.Equal(t, "6448000111", ev.AppleAppID)
+	require.Equal(t, tenantID, ev.TenantID)
+	require.Equal(t, storeID, ev.StoreID)
+	// Decision 5: FirebaseProjectID is the service account's project_id.
+	require.Equal(t, "merchant-app-42", ev.FirebaseProjectID)
+	// Decision 4: no source for a Play package, so none is invented.
+	require.Empty(t, ev.GooglePackage)
+}
+
+// Zero apps is a conclusion ("this account publishes nothing we can
+// retire"), not a licence to seed an empty row.
+func TestDiscover_ZeroApps_Refuses(t *testing.T) {
+	d := discoveryWith(nil, nil, &stubCreds{})
+
+	_, err := d.discover(context.Background(), uuid.New(), uuid.New())
+	require.ErrorIs(t, err, ErrNoAppleApp)
+	require.NotErrorIs(t, err, ErrAmbiguousAppleApp, "zero and many must be distinct errors")
+}
+
+// Picking one of several would retire a listing belonging to a merchant
+// who did not cancel.
+func TestDiscover_MultipleApps_Refuses(t *testing.T) {
+	d := discoveryWith([]apple.App{
+		{ID: "111", BundleID: "com.merchant.shop"},
+		{ID: "222", BundleID: "com.merchant.other"},
+	}, nil, &stubCreds{})
+
+	_, err := d.discover(context.Background(), uuid.New(), uuid.New())
+	require.ErrorIs(t, err, ErrAmbiguousAppleApp)
+	require.NotErrorIs(t, err, ErrNoAppleApp, "many and zero must be distinct errors")
+	// The refusal must name what it saw, or an operator cannot act on it.
+	require.Contains(t, err.Error(), "111")
+	require.Contains(t, err.Error(), "222")
+}
+
+// A rejected key is "we do not know what exists", which must not be
+// reported as either of the two conclusions.
+func TestDiscover_ListAppsError_IsNeitherRefusal(t *testing.T) {
+	d := discoveryWith(nil, apple.ErrUnauthorized, &stubCreds{})
+
+	_, err := d.discover(context.Background(), uuid.New(), uuid.New())
+	require.ErrorIs(t, err, apple.ErrUnauthorized)
+	require.NotErrorIs(t, err, ErrNoAppleApp)
+	require.NotErrorIs(t, err, ErrAmbiguousAppleApp)
+}
+
+// Firebase is best-effort: a missing Play service account narrows the
+// teardown, it does not invalidate the Apple half.
+func TestDiscover_MissingPlayCredentials_StillDiscoversApple(t *testing.T) {
+	d := discoveryWith([]apple.App{{ID: "999"}}, nil, &stubCreds{err: appcreds.ErrNotFound})
+
+	ev, err := d.discover(context.Background(), uuid.New(), uuid.New())
+	require.NoError(t, err)
+	require.Equal(t, "999", ev.AppleAppID)
+	require.Empty(t, ev.FirebaseProjectID)
+}
+
+func TestDiscover_UnparseablePlayCredentials_StillDiscoversApple(t *testing.T) {
+	d := discoveryWith([]apple.App{{ID: "999"}}, nil, &stubCreds{
+		byType: map[appcreds.CredType][]byte{
+			appcreds.CredTypeGooglePlayJSON: []byte(`{"type":"authorized_user"}`),
+		},
+	})
+
+	ev, err := d.discover(context.Background(), uuid.New(), uuid.New())
+	require.NoError(t, err)
+	require.Empty(t, ev.FirebaseProjectID)
+}
+
+func TestProAppCancelled_WithoutDiscovery_Refuses(t *testing.T) {
+	c := NewProAppCancelledConsumer(nil, nil)
+	err := c.ProAppCancelled(context.Background(), uuid.New(), uuid.New())
+	require.ErrorIs(t, err, ErrDiscoveryNotConfigured)
+}
+
+// A discovery refusal must surface to the caller (the finalize cron
+// logs it) and must not reach the database.
+func TestProAppCancelled_DiscoveryRefusal_NeverSeeds(t *testing.T) {
+	// db is nil: any attempt to seed would panic or error rather than
+	// silently succeed.
+	c := NewProAppCancelledConsumer(nil, nil).
+		WithDiscovery(discoveryWith(nil, nil, &stubCreds{}))
+
+	err := c.ProAppCancelled(context.Background(), uuid.New(), uuid.New())
+	require.ErrorIs(t, err, ErrNoAppleApp)
+}
+
+func TestNewAppleListerFactory_PropagatesCredentialErrors(t *testing.T) {
+	boom := errors.New("secret manager unavailable")
+	factory := NewAppleListerFactory(&stubCreds{err: boom})
+
+	lister, err := factory(context.Background(), uuid.New(), uuid.New())
+	require.NoError(t, err, "the client is built lazily; credentials are fetched per call")
+	_, err = lister.ListApps(context.Background())
+	require.ErrorIs(t, err, boom)
+}
+
+// ─── Coverage note ───────────────────────────────────────────────────
+
+// With GooglePackage empty by design, the advancer's `if
+// r.GooglePackage != ""` guards mean Play is never attempted, never
+// errors and never logs. The row must therefore say so itself.
+func TestTeardownCoverage_StatesPlayIsNotAttempted(t *testing.T) {
+	note := teardownCoverage(ProAppCancelledEvent{
+		AppleAppID:        "6448000111",
+		FirebaseProjectID: "merchant-app-42",
+	})
+
+	require.Contains(t, note, "google_play=NOT_ATTEMPTED")
+	require.Contains(t, strings.ToLower(note), "no package identifier")
+	require.Contains(t, strings.ToLower(note), "stub")
+	require.Contains(t, note, "apple=will_attempt(app_id=6448000111)")
+	require.Contains(t, note, "merchant-app-42")
+	// A placeholder package would make the guard fire while asserting an
+	// identifier nobody has — decision 4 exists to prevent that.
+	require.NotContains(t, note, "google_play=will_attempt")
+}
+
+func TestTeardownCoverage_NamesPlayPackageWhenOneExists(t *testing.T) {
+	note := teardownCoverage(ProAppCancelledEvent{
+		AppleAppID:    "1",
+		GooglePackage: "com.merchant.shop",
+	})
+	require.Contains(t, note, "google_play=will_attempt(package=com.merchant.shop)")
+	require.NotContains(t, note, "NOT_ATTEMPTED")
+}

--- a/services/marketplace-api/internal/whitelabel/lifecycle/pro_app_cancelled_consumer.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/pro_app_cancelled_consumer.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+
+	"github.com/mark8ly/marketplace-api/internal/subscription"
 )
 
 // ProAppCancelledEvent is the shape consumed when subscription emits
@@ -52,8 +56,10 @@ var ErrNoAppIdentifiers = errors.New("lifecycle/consumer: event carries no Apple
 // compresses into ~7 days of real time (§15.5 "immediate-pull compresses
 // to 7 days").
 type ProAppCancelledConsumer struct {
-	db    *gorm.DB
-	clock Clock
+	db        *gorm.DB
+	clock     Clock
+	discovery *Discovery
+	logger    *slog.Logger
 }
 
 // NewProAppCancelledConsumer wires the consumer. Clock defaults to
@@ -62,7 +68,49 @@ func NewProAppCancelledConsumer(db *gorm.DB, clock Clock) *ProAppCancelledConsum
 	if clock == nil {
 		clock = time.Now
 	}
-	return &ProAppCancelledConsumer{db: db, clock: clock}
+	return &ProAppCancelledConsumer{db: db, clock: clock, logger: slog.Default()}
+}
+
+// WithDiscovery returns a copy of the consumer that can resolve
+// identifiers for itself, enabling ProAppCancelled. Handle is unaffected
+// — a caller that already knows the identifiers still uses it directly.
+func (c *ProAppCancelledConsumer) WithDiscovery(d *Discovery) *ProAppCancelledConsumer {
+	next := *c
+	next.discovery = d
+	return &next
+}
+
+// WithLogger returns a copy of the consumer logging to l.
+func (c *ProAppCancelledConsumer) WithLogger(l *slog.Logger) *ProAppCancelledConsumer {
+	if l == nil {
+		return c
+	}
+	next := *c
+	next.logger = l
+	return &next
+}
+
+// ProAppCancelled discovers the store's app identifiers and seeds the
+// teardown row. It is the method the subscription finalize cron calls
+// through the small notifier interface that package defines — an
+// in-process call, deliberately not pub/sub: the emitter and the
+// consumer run in the same binary, and a topic would add a delivery
+// failure mode without adding a capability.
+//
+// Discovery runs here, at cancellation, because the advancer purges the
+// credentials it needs at day 90 (see Discovery).
+func (c *ProAppCancelledConsumer) ProAppCancelled(ctx context.Context, tenantID, storeID uuid.UUID) error {
+	if c.discovery == nil {
+		return ErrDiscoveryNotConfigured
+	}
+	ev, err := c.discovery.discover(ctx, tenantID, storeID)
+	if err != nil {
+		return err
+	}
+	// The cron path is the graceful 60-day teardown. The compressed
+	// merchant-initiated path (§15.5) enters through Handle directly.
+	ev.MerchantInitiatedImmediate = false
+	return c.Handle(ctx, ev)
 }
 
 // validateEvent rejects events that cannot produce a meaningful
@@ -138,5 +186,101 @@ func (c *ProAppCancelledConsumer) Handle(ctx context.Context, ev ProAppCancelled
 	if res.Error != nil {
 		return fmt.Errorf("lifecycle/consumer: insert: %w", res.Error)
 	}
+	if res.RowsAffected == 0 {
+		// ON CONFLICT DO NOTHING fired: a row already exists for this
+		// store. Replay, not a new teardown — do not append a second
+		// coverage note to the append-only log.
+		return nil
+	}
+
+	coverage := teardownCoverage(ev)
+	// Say at seed time what this teardown will and will not reach. The
+	// log line is for whoever is watching the cancellation; the
+	// white_label_app_lifecycle row below is the durable half, still
+	// readable in ninety days when the state row has advanced to
+	// credentials_purged and no longer shows how it got there.
+	c.log().InfoContext(ctx, "lifecycle/consumer: teardown seeded",
+		"store_id", ev.StoreID, "tenant_id", ev.TenantID, "coverage", coverage)
+	if err := c.appendCoverageNote(ctx, ev, now, coverage); err != nil {
+		// The state row is committed and the teardown will run; failing
+		// the whole Handle here would make the caller retry a seed that
+		// already succeeded. Log loudly instead.
+		c.log().ErrorContext(ctx, "lifecycle/consumer: teardown seeded but coverage note not recorded",
+			"store_id", ev.StoreID, "err", err)
+	}
 	return nil
+}
+
+// seedActor is the actor recorded on the seed-time coverage note.
+const seedActor = "system:consumer:pro_app_cancelled"
+
+// appendCoverageNote writes one row into the append-only
+// white_label_app_lifecycle log stating what this teardown covers.
+func (c *ProAppCancelledConsumer) appendCoverageNote(ctx context.Context, ev ProAppCancelledEvent, now time.Time, coverage string) error {
+	scheduled := now
+	entry := subscription.WhiteLabelAppLifecycleEntry{
+		ID:          uuid.New(),
+		StoreID:     ev.StoreID,
+		TenantID:    ev.TenantID,
+		Status:      StatusSunsetScheduled,
+		ScheduledAt: &scheduled,
+		Actor:       seedActor,
+		Reason:      &coverage,
+	}
+	if err := c.db.WithContext(ctx).Create(&entry).Error; err != nil {
+		return fmt.Errorf("lifecycle/consumer: append coverage note: %w", err)
+	}
+	return nil
+}
+
+// teardownCoverage renders, per surface, what this row will and will not
+// retire.
+//
+// WHY THIS EXISTS RATHER THAN A PLACEHOLDER IDENTIFIER: the advancer
+// guards both of its Google calls with `if r.GooglePackage != ""`
+// (advancer.go), and GooglePackage is empty by design — there is no
+// source for it and the Play client is an unimplemented stub. So Play is
+// never attempted, never errors, and never logs: the row would advance
+// all the way to credentials_purged having said nothing whatsoever about
+// Google, which is the same "we report a teardown we never performed"
+// failure this whole path exists to prevent, one level down.
+//
+// Filling GooglePackage with a placeholder to make the guard fire would
+// be worse: it trades a silent skip for a row asserting an identifier
+// nobody has. So the absence is stated in words, durably, instead.
+func teardownCoverage(ev ProAppCancelledEvent) string {
+	parts := make([]string, 0, 3)
+
+	if ev.AppleAppID != "" {
+		parts = append(parts, fmt.Sprintf("apple=will_attempt(app_id=%s)", ev.AppleAppID))
+	} else {
+		parts = append(parts, "apple=not_attempted(no App Store Connect app id was discovered)")
+	}
+
+	if ev.GooglePackage != "" {
+		parts = append(parts, fmt.Sprintf("google_play=will_attempt(package=%s)", ev.GooglePackage))
+	} else {
+		parts = append(parts, "google_play=NOT_ATTEMPTED(no package identifier is discoverable at cancel time, "+
+			"and the Play client is an unimplemented stub returning ErrNotWired; "+
+			"the advancer's day-30 and day-60 Google calls are guarded on google_package "+
+			"and will not run for this row — the merchant's Play listing, if any, stays live)")
+	}
+
+	if ev.FirebaseProjectID != "" {
+		parts = append(parts, fmt.Sprintf(
+			"firebase=will_attempt(project=%s, inferred from the Google Play service account's project_id; "+
+				"the Firebase client is a stub, so the attempt is logged rather than effective)",
+			ev.FirebaseProjectID))
+	} else {
+		parts = append(parts, "firebase=not_attempted(no project id was discovered)")
+	}
+
+	return strings.Join(parts, "; ")
+}
+
+func (c *ProAppCancelledConsumer) log() *slog.Logger {
+	if c.logger != nil {
+		return c.logger
+	}
+	return slog.Default()
 }

--- a/services/marketplace-api/internal/whitelabel/lifecycle/pro_app_cancelled_consumer_integration_test.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/pro_app_cancelled_consumer_integration_test.go
@@ -9,7 +9,10 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 
+	"github.com/mark8ly/marketplace-api/internal/subscription"
+	"github.com/mark8ly/marketplace-api/internal/whitelabel/apple"
 	"github.com/mark8ly/marketplace-api/internal/whitelabel/lifecycle"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
@@ -129,4 +132,111 @@ func TestConsumer_NoIdentifiers_WritesNoRow(t *testing.T) {
 	var count int64
 	db.Model(&lifecycle.Row{}).Where("store_id=?", storeID).Count(&count)
 	require.Zero(t, count, "a refused event must leave no row for the advancer")
+}
+
+// ─── Seed-time coverage note (#702) ──────────────────────────────────
+
+// countCoverageNotes returns the seed-time coverage rows for a store.
+func coverageNotes(t *testing.T, db *gorm.DB, storeID uuid.UUID) []subscription.WhiteLabelAppLifecycleEntry {
+	t.Helper()
+	var entries []subscription.WhiteLabelAppLifecycleEntry
+	require.NoError(t, db.Where("store_id = ? AND actor = ?", storeID, "system:consumer:pro_app_cancelled").
+		Find(&entries).Error)
+	return entries
+}
+
+// With google_package empty by design (decision 4), the advancer's
+// `if r.GooglePackage != ""` guards mean Play is never attempted, never
+// errors and never logs — the row would otherwise reach
+// credentials_purged having said nothing at all about Google. The
+// durable statement is what stops that.
+func TestConsumer_RecordsPlayAsNotAttempted(t *testing.T) {
+	db := testdb.NewDB(t, "white_label_app_state", "white_label_app_lifecycle")
+	c := lifecycle.NewProAppCancelledConsumer(db, nil)
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	require.NoError(t, c.Handle(context.Background(), lifecycle.ProAppCancelledEvent{
+		TenantID: tenantID, StoreID: storeID,
+		AppleAppID: "6448000111", FirebaseProjectID: "merchant-app-42",
+	}))
+
+	// The state row must NOT carry a placeholder package.
+	var row lifecycle.Row
+	require.NoError(t, db.Where("store_id=?", storeID).First(&row).Error)
+	require.Empty(t, row.GooglePackage, "no placeholder identifier may be invented")
+
+	notes := coverageNotes(t, db, storeID)
+	require.Len(t, notes, 1)
+	require.NotNil(t, notes[0].Reason)
+	require.Contains(t, *notes[0].Reason, "google_play=NOT_ATTEMPTED")
+	require.Contains(t, *notes[0].Reason, "apple=will_attempt(app_id=6448000111)")
+	require.Equal(t, lifecycle.StatusSunsetScheduled, notes[0].Status)
+}
+
+// Replay must not append a second note: ON CONFLICT DO NOTHING means no
+// new teardown was scheduled, so nothing new happened to record.
+func TestConsumer_Replay_AppendsOneCoverageNote(t *testing.T) {
+	db := testdb.NewDB(t, "white_label_app_state", "white_label_app_lifecycle")
+	c := lifecycle.NewProAppCancelledConsumer(db, nil)
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	ev := lifecycle.ProAppCancelledEvent{TenantID: tenantID, StoreID: storeID, AppleAppID: "a1"}
+	require.NoError(t, c.Handle(context.Background(), ev))
+	require.NoError(t, c.Handle(context.Background(), ev))
+
+	require.Len(t, coverageNotes(t, db, storeID), 1)
+}
+
+// End-to-end through the delivery path the finalize cron uses: one ASC
+// app discovered, row seeded, Play stated as not attempted.
+func TestProAppCancelled_DiscoversAndSeeds(t *testing.T) {
+	db := testdb.NewDB(t, "white_label_app_state", "white_label_app_lifecycle")
+
+	fake := apple.NewFakeClient()
+	fake.Apps = []apple.App{{ID: "6448000111", BundleID: "com.merchant.shop"}}
+	c := lifecycle.NewProAppCancelledConsumer(db, nil).
+		WithDiscovery(&lifecycle.Discovery{
+			Apple: func(context.Context, uuid.UUID, uuid.UUID) (lifecycle.AppleLister, error) {
+				return fake, nil
+			},
+			// No credential loader: the Play service account is
+			// unavailable, so no Firebase project is discovered.
+		})
+
+	tenantID, storeID := uuid.New(), uuid.New()
+	require.NoError(t, c.ProAppCancelled(context.Background(), tenantID, storeID))
+
+	var row lifecycle.Row
+	require.NoError(t, db.Where("store_id=?", storeID).First(&row).Error)
+	require.Equal(t, "6448000111", row.AppleAppID)
+	require.Empty(t, row.GooglePackage)
+	require.Equal(t, lifecycle.StatusSunsetScheduled, row.Status)
+	require.False(t, row.MerchantInitiated)
+
+	notes := coverageNotes(t, db, storeID)
+	require.Len(t, notes, 1)
+	require.Contains(t, *notes[0].Reason, "google_play=NOT_ATTEMPTED")
+}
+
+// An ambiguous account seeds nothing at all.
+func TestProAppCancelled_AmbiguousAccount_SeedsNothing(t *testing.T) {
+	db := testdb.NewDB(t, "white_label_app_state", "white_label_app_lifecycle")
+
+	fake := apple.NewFakeClient()
+	fake.Apps = []apple.App{{ID: "111"}, {ID: "222"}}
+	c := lifecycle.NewProAppCancelledConsumer(db, nil).
+		WithDiscovery(&lifecycle.Discovery{
+			Apple: func(context.Context, uuid.UUID, uuid.UUID) (lifecycle.AppleLister, error) {
+				return fake, nil
+			},
+		})
+
+	storeID := uuid.New()
+	err := c.ProAppCancelled(context.Background(), uuid.New(), storeID)
+	require.ErrorIs(t, err, lifecycle.ErrAmbiguousAppleApp)
+
+	var count int64
+	db.Model(&lifecycle.Row{}).Where("store_id=?", storeID).Count(&count)
+	require.Zero(t, count)
+	require.Empty(t, coverageNotes(t, db, storeID))
 }


### PR DESCRIPTION
Progresses #702. **Does not close it** — see "What still does not work".

When a Pro+App merchant cancels, `finalize.go` emitted an audit event and then logged that it "would notify" a service that did not exist. The consumer that retires the app was written, tested, and never constructed. Nothing seeded `white_label_app_state`, the advancer ran forever over an empty table, and the merchant's app stayed live indefinitely.

## The issue named two gaps. There were four.

| gap | named in #702? |
|---|---|
| the consumer is never constructed | yes |
| no source for the app identifiers | yes |
| **`googleplay` and `firebase` clients are unimplemented stubs** | no |
| **production wires ALL THREE clients as fakes, Apple included** | no |

The fourth is the one that matters most, and it was found only while building. `main.go` had `wlAppleCli := wlapple.NewFakeClient()`. So the advancer called a fake `BlockDownloads` at day 30 and a fake `PullApp` at day 60, then wrote `downloads_blocked` and `pulled` into the append-only lifecycle table — **an audit row asserting a teardown that touched nothing.**

That was latent only because nothing seeded rows. Wiring the consumer is what fills the table, and the consumer's own comment notes an immediate cancellation seeds a row already overdue, so the advancer acts on the next tick. **Wiring the consumer without fixing the clients would have activated a false audit trail**, which is the precise failure this issue exists to fix.

## What this does

**Discovery, not a source of record.** There is no provisioning flow to record identifiers at, so they are resolved at teardown from credentials already stored. `apple.ListApps` (new) reads ASC `/v1/apps` with the existing ES256-JWT auth. It follows `links.next`, capped and erroring rather than truncating — a truncated list turns an ambiguous account into a falsely unambiguous one and pulls the wrong merchant's listing. It refuses an off-host `next`, since the Bearer token rides every hop.

**Zero apps and more than one both REFUSE, by distinct named errors.** A wrong app id retires a listing belonging to a merchant who did not cancel. That is worse than retiring nothing.

**Discovery runs at cancel time, not lazily** — the advancer purges all four credential types at day 90, and a teardown reaching `credentials_purged` without having discovered anything has permanently lost the ability to.

**Per-tenant clients.** `apple.Client` and `googleplay.Client` both take a tenant-less `CredsFetcher`, so one client structurally cannot serve a multi-tenant cohort. Both are now per-row factories. Production no longer constructs a single fake teardown client of any kind.

**A resolution failure stalls the row rather than advancing it.** A row whose merchant we cannot authenticate as has not been torn down. It retries every tick with an ERROR log. The accepted cost, stated rather than hidden: a permanently revoked ASC key means that row never reaches the day-90 purge. A stuck-but-loud row beats a false audit trail.

## Three things that are not done, and say so in writing

The whole subject of this issue is a system reporting work it did not do, so every remaining gap is recorded durably rather than implied:

- **Google Play is never attempted.** No package identifier is discoverable and the client is a stub. `advancer.go` guards its Play calls on `google_package != ""`, so with that field empty the tolerate-and-log branch is **unreachable** — Play would have been skipped in total silence. The seed now writes a `NOT_ATTEMPTED` note naming why, into the same append-only table.
- **Firebase archive is logged, not performed.** The status `firebase_archived` is a fixed value the state machine reads to reach day 90 and cannot be made to say otherwise; erroring would stall every row forever, since the stub never succeeds. So a lifecycle row now carries the reason beside the status, naming the project and what did not happen.
- **`FirebaseProjectID` is an inference.** It is the service-account JSON's `project_id` — the GCP project of the Play publisher account, usually but not necessarily the Firebase project. Documented at the source. Whoever implements the Firebase client must verify the project before deleting it, not trust the column.

## What still does not work

Only the **App Store** listing is genuinely retired. Play and Firebase are not, because their clients are unimplemented. #702 stays open for those.

## Verification

Integration tests **ran** against a real Postgres with all migrations applied — zero skips, which matters because `pkg/testdb` skips silently when `TEST_DATABASE_URL` is unset. `internal/whitelabel/lifecycle`: 19 unit + 38 integration. `internal/subscription/lifecycle`: 14 unit + 25 integration. Build and vet clean under both tag sets.

Every guard carrying weight was mutation-checked, each verified to have actually landed before running: refuse-on-multiple-apps, refuse-on-unresolvable-client, the pagination follow, the read-only assertion on `ListApps`, and the Firebase not-performed note.

## Open question I could not settle

**Do a merchant's ASC credentials scope to one app, or to their whole team?** If the latter, `ErrAmbiguousAppleApp` becomes the normal outcome and discovery refuses for everyone — safe, since it refuses rather than pulling the wrong listing, but teardown would never fire. Nothing here has been exercised against real App Store Connect; `ListApps` pagination and the 401/403 mapping are taken from Apple's documented contract, not observed. **Checking one real tenant's credentials against `/v1/apps` before relying on this is worth doing.**
