### PR TITLE
chore(marketplace-api): ship the trial backfill binary so it can run where the data is (#827)

### DIFF
--- a/services/marketplace-api/Dockerfile
+++ b/services/marketplace-api/Dockerfile
@@ -43,7 +43,9 @@ RUN go build -trimpath -ldflags="-s -w" \
  && go build -trimpath -ldflags="-s -w" \
       -o /out/webhook-delivery-prune-cron ./cmd/webhook-delivery-prune-cron \
  && go build -trimpath -ldflags="-s -w" \
-      -o /out/carrier-secrets-backfill ./cmd/carrier-secrets-backfill
+      -o /out/carrier-secrets-backfill ./cmd/carrier-secrets-backfill \
+ && go build -trimpath -ldflags="-s -w" \
+      -o /out/backfill-trial-start ./cmd/backfill-trial-start
 
 # ─── migrate ────────────────────────────────────────────────────────────
 # Standalone image used by the K8s Job pattern.
@@ -75,5 +77,14 @@ COPY --from=builder --chown=10001:10001 /out/webhook-delivery-prune-cron /usr/lo
 # under the real ServiceAccount, rather than from an operator's laptop with
 # production credentials port-forwarded to it.
 COPY --from=builder --chown=10001:10001 /out/carrier-secrets-backfill /usr/local/bin/carrier-secrets-backfill
+# backfill-trial-start is the same shape of tool: a ONE-OFF, run by hand as a
+# Job to give stores created before #828 the subscription row — and therefore
+# the trial clock — that nothing created for them at signup (mark8ly#827).
+#
+# Shipped for the same reason as the one above, and for a sharper one: it was
+# written, merged and left out of this image, so the command existed and could
+# not be run anywhere the data lives. It reports what it would write and needs
+# -apply to write anything.
+COPY --from=builder --chown=10001:10001 /out/backfill-trial-start /usr/local/bin/backfill-trial-start
 EXPOSE 8091
 CMD ["/usr/local/bin/marketplace-api"]


### PR DESCRIPTION
`cmd/backfill-trial-start` was written in #828, corrected in #841, and is not in the runtime image — so it cannot run anywhere the data lives.

Same shape as the defect #841 fixed, one layer out: the command existed, was tested, and could not be executed. `carrier-secrets-backfill` is already shipped for exactly this reason, and its comment says why — "so it runs in-cluster under the real ServiceAccount, rather than from an operator's laptop with production credentials port-forwarded to it".

## Verified, not assumed

Built the runtime target locally and ran the binary out of the image:

```
$ docker run --rm --entrypoint /usr/local/bin/backfill-trial-start <image> -h
Usage of /usr/local/bin/backfill-trial-start:
  -apply
        actually write rows (default: report only)
  -batch int
        rows fetched per DB scan (default 200)
```

Given the last two PRs in this chain were both "it was never actually run", checking the binary starts seemed like the minimum.

## What this unblocks

#827's remaining step. In production right now: 4 stores, 0 subscriptions, schema at 135 — so migration 136 (which adds `stores.created_at`) has not deployed yet either.

The order that has to hold:

1. #841 deploys — `stores.created_at` exists
2. This deploys — the binary exists
3. The four existing projection rows learn their `created_at`; they hold NULL until platform-api re-sends them, and the backfill skips and counts undated rows rather than guessing
4. `backfill-trial-start` dry run, read the summary, then `-apply`

Two of the four backfill as already-expired trials (created 132 and 102 days ago). Both are team stores from before there were merchants, so nothing is billed and nothing is taken away.

## Test plan

- [x] `docker build --target runtime` succeeds
- [x] The binary is present in the image and runs
- [x] No Go changes — the command and its tests are unchanged from #841
