### PR TITLE
fix(stores): stop GORM stamping the mirrored creation date on every sync (#827)

### DIFF
--- a/services/marketplace-api/internal/stores/models.go
+++ b/services/marketplace-api/internal/stores/models.go
@@ -26,7 +26,20 @@ type Store struct {
 	// NOT SyncedAt. That is when this projection last copied the row and
 	// moves on every upsert, so using it would date a trial from the last
 	// time a merchant edited their store settings.
-	CreatedAt *time.Time `gorm:"column:created_at"                                       json:"created_at,omitempty"`
+	//
+	// autoCreateTime:false is LOAD-BEARING. GORM auto-populates any field
+	// named CreatedAt with the current time on Create, and Upsert uses
+	// Create with an ON CONFLICT clause — so without this tag every upsert
+	// sends now(), the COALESCE below prefers it, and the mirrored creation
+	// date is overwritten with the moment of the last sync.
+	//
+	// That is not hypothetical: it happened in production. Four stores had
+	// their real dates replaced within minutes of the column shipping, and
+	// the trial backfill would then have granted a fresh 90 days to a store
+	// created in April. Renaming the field would also fix it; the tag is
+	// kept because `created_at` is the column's name in platform_api and
+	// matching it is worth one annotation.
+	CreatedAt *time.Time `gorm:"column:created_at;autoCreateTime:false"                  json:"created_at,omitempty"`
 	SyncedAt  time.Time  `gorm:"column:synced_at;not null;default:now()"                 json:"synced_at"`
 	// StorefrontCustomerPortalSecret is the per-store HMAC key for customer
 	// portal tokens (§15.4, migration 058). Generated at migration time;

--- a/services/marketplace-api/internal/stores/upsert_created_at_integration_test.go
+++ b/services/marketplace-api/internal/stores/upsert_created_at_integration_test.go
@@ -1,0 +1,119 @@
+//go:build integration
+
+package stores_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/stores"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+// These pin the one behaviour of stores.created_at that has already broken in
+// production (#827).
+//
+// GORM auto-populates any field named CreatedAt on Create, and Upsert is a
+// Create with an ON CONFLICT clause. So the column shipped, every upsert began
+// sending now(), the ON CONFLICT rule preferred the incoming value, and four
+// stores had their real creation dates replaced with the moment of the last
+// sync — inside minutes, silently.
+//
+// The consequence was not cosmetic: the trial backfill dates a trial from this
+// column, so a store created in April would have been handed a fresh 90-day
+// trial. Only a dry run caught it.
+//
+// A unit test cannot see any of this. The overwrite happens in SQL GORM
+// generates, against a real ON CONFLICT clause.
+
+func upsertStore(t *testing.T, repo stores.Repository, id, tenant uuid.UUID, createdAt *time.Time) {
+	t.Helper()
+	require.NoError(t, repo.Upsert(context.Background(), &stores.Store{
+		ID:           id.String(),
+		TenantID:     tenant.String(),
+		Slug:         "s-" + id.String()[:8],
+		Name:         "Test Store",
+		CountryCode:  "AU",
+		CurrencyCode: "AUD",
+		Timezone:     "Australia/Sydney",
+		Status:       "active",
+		CreatedAt:    createdAt,
+		SyncedAt:     time.Now().UTC(),
+	}))
+}
+
+func loadStore(t *testing.T, repo stores.Repository, id, tenant uuid.UUID) *stores.Store {
+	t.Helper()
+	got, err := repo.GetByIDForTenant(context.Background(), id.String(), tenant.String())
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	return got
+}
+
+func loadCreatedAt(t *testing.T, repo stores.Repository, id, tenant uuid.UUID) *time.Time {
+	t.Helper()
+	return loadStore(t, repo, id, tenant).CreatedAt
+}
+
+// The regression itself: a caller that sends no created_at must leave the
+// stored one alone. Before autoCreateTime:false, GORM filled it with now() and
+// the upsert overwrote a real date on every sync.
+func TestUpsert_DoesNotOverwriteCreatedAtWhenTheCallerSendsNone(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := stores.NewRepository(db)
+
+	id, tenant := uuid.New(), uuid.New()
+	original := time.Date(2026, 4, 29, 12, 11, 3, 0, time.UTC)
+
+	upsertStore(t, repo, id, tenant, &original)
+	require.WithinDuration(t, original, *loadCreatedAt(t, repo, id, tenant), time.Second)
+
+	// The sync that used to destroy it.
+	upsertStore(t, repo, id, tenant, nil)
+
+	got := loadCreatedAt(t, repo, id, tenant)
+	require.NotNil(t, got, "created_at was nulled by a sync that did not carry one")
+	require.WithinDuration(t, original, *got, time.Second,
+		"a sync overwrote the store's real creation date")
+}
+
+// The other half of the COALESCE: a row mirrored before migration 136 holds
+// NULL and must be able to learn its date from the next sync.
+func TestUpsert_FillsCreatedAtWhenTheStoredValueIsNull(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := stores.NewRepository(db)
+
+	id, tenant := uuid.New(), uuid.New()
+	upsertStore(t, repo, id, tenant, nil)
+	require.Nil(t, loadCreatedAt(t, repo, id, tenant))
+
+	known := time.Date(2026, 4, 29, 12, 11, 3, 0, time.UTC)
+	upsertStore(t, repo, id, tenant, &known)
+
+	got := loadCreatedAt(t, repo, id, tenant)
+	require.NotNil(t, got, "a known creation date did not fill a NULL")
+	require.WithinDuration(t, known, *got, time.Second)
+}
+
+// created_at and synced_at must not track each other. They did, exactly, when
+// the bug was live — which is the tell an operator would have to notice.
+func TestUpsert_CreatedAtDoesNotFollowSyncedAt(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := stores.NewRepository(db)
+
+	id, tenant := uuid.New(), uuid.New()
+	original := time.Date(2026, 4, 29, 12, 11, 3, 0, time.UTC)
+	upsertStore(t, repo, id, tenant, &original)
+
+	time.Sleep(10 * time.Millisecond)
+	upsertStore(t, repo, id, tenant, nil)
+
+	got := loadStore(t, repo, id, tenant)
+	require.NotNil(t, got.CreatedAt)
+	require.True(t, got.SyncedAt.Sub(*got.CreatedAt) > time.Hour,
+		"created_at moved with synced_at: created=%s synced=%s", got.CreatedAt, got.SyncedAt)
+}


### PR DESCRIPTION
`stores.created_at`, added in #841, was overwritten on every sync. Four production stores lost their real creation dates within minutes of the column shipping.

**GORM auto-populates any field named `CreatedAt` with the current time on Create**, and `Upsert` is a `Create` with an `ON CONFLICT` clause. So every upsert sent `now()`, the `COALESCE(EXCLUDED.created_at, stores.created_at)` rule preferred the incoming value exactly as designed, and the mirrored date became the moment of the last sync.

The tell was there in the data:

```
demo-store       | 2026-09-08 01:50:05.597344+00 | synced 2026-09-08 01:50:05.595653+00
the-bondi-store  | 2026-09-08 01:50:05.386567+00 | synced 2026-09-08 01:50:05.385254+00
```

`created_at` sitting ~1.5 ms after `synced_at` on every row — GORM stamping it while building the insert, just after the handler set `synced_at`.

## Why this mattered more than a wrong timestamp

The trial backfill dates a trial from this column. With every store reading as created today, `the-bondi-store` — created 29 April — would have been granted a **fresh 90-day trial** instead of the expired one it should get. That is precisely the outcome #827's design set out to prevent, reintroduced by the mechanism meant to enable it.

**It was caught by the dry run**, in the last step before `-apply`. Nothing was written.

## The fix

`autoCreateTime:false` on the field. Renaming it would work too; the tag is kept because `created_at` is the column's name in `platform_api` and matching the source is worth one annotation.

The COALESCE is now doing the job it was written for: with GORM no longer inventing a value, a caller that sends nothing sends NULL, and the stored date survives.

## Tests

Three integration tests, because none of this is visible to a unit test — the overwrite happens in SQL GORM generates against a real `ON CONFLICT` clause:

- a sync carrying **no** `created_at` leaves the stored one alone — the regression itself
- a sync carrying a known date still fills a NULL, so pre-136 rows can learn theirs
- `created_at` does not track `synced_at`, which is the signature the bug left in production

## Test plan

- [x] `gofmt`, `go build`, `go vet ./...`, full marketplace-api suite green
- [x] `go vet -tags integration ./...` clean
- [ ] The integration tests run first in CI — the LAN Postgres is still unreachable from this machine
- [ ] After deploy: re-apply the four correct dates from `platform_api.stores`, confirm they survive a sync, then re-run the backfill dry run

## Production state

Those four rows currently hold today's date. They are re-fixable from `platform_api.stores` — which is untouched and authoritative — once this deploys, and there is no point doing it before then because the next sync would overwrite them again. The backfill has **not** been applied; `store_subscriptions` is still empty.
