### PR TITLE
fix(subscription): start trials in trialing, so something actually ends them (#827)

### DIFF
--- a/services/marketplace-api/internal/subscription/bootstrap_test.go
+++ b/services/marketplace-api/internal/subscription/bootstrap_test.go
@@ -122,8 +122,11 @@ func TestBootstrap_CreatesTheRowWithNoStripeClientAtAll(t *testing.T) {
 	if sub.Plan != subscription.PlanTrial {
 		t.Errorf("plan = %q, want trial", sub.Plan)
 	}
-	if sub.Status != subscription.StatusSignup {
-		t.Errorf("status = %q, want signup", sub.Status)
+	// trialing, not signup (#827). signup is a resting state that ExpiryCron
+	// does not select, so a row created there has a trial_ends_at nothing
+	// ever acts on — the clock starts and never rings.
+	if sub.Status != subscription.StatusTrialing {
+		t.Errorf("status = %q, want trialing", sub.Status)
 	}
 	if sub.StripeCustomerID != "" {
 		t.Errorf("StripeCustomerID = %q, want empty — Bootstrap must not mint one", sub.StripeCustomerID)
@@ -325,5 +328,24 @@ func TestBootstrap_StoresNeitherHalfOfAnIncompleteTaxID(t *testing.T) {
 					sub.ReverseChargeTaxID, sub.TaxIDCountry)
 			}
 		})
+	}
+}
+
+// The specific regression: a row created in signup is invisible to
+// ExpiryCron, which selects trialing. Four production stores sat in exactly
+// that state after #827's backfill, two of them weeks past their trial end
+// and swept by nothing.
+func TestBootstrap_CreatesARowTheExpiryCronCanSee(t *testing.T) {
+	svc := newSvc(&bootstrapRepo{}, nil)
+
+	sub, err := svc.Bootstrap(context.Background(), bootstrapInput())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if sub.Status == subscription.StatusSignup {
+		t.Fatal("created in signup — ExpiryCron selects trialing, so this trial would never end")
+	}
+	if sub.Status != subscription.StatusTrialing {
+		t.Fatalf("status = %q, want trialing", sub.Status)
 	}
 }

--- a/services/marketplace-api/internal/subscription/models.go
+++ b/services/marketplace-api/internal/subscription/models.go
@@ -62,24 +62,36 @@ func AllStatuses() []SubscriptionStatus {
 type SubscriptionStatus string
 
 const (
-	// StatusSignup is where `Bootstrap` puts every new row, and it is a
-	// RESTING STATE, not a transient one. Documented rather than fixed, on
+	// StatusSignup is a RESTING STATE, not a transient one.
+	//
+	// CORRECTED (#827): it is no longer where Bootstrap puts new rows.
+	// Bootstrap creates `trialing`, because its only caller is onboarding
+	// completion and §17.2 promotes signup → trialing on "email verified",
+	// which a completed onboarding has by definition. Rows left in signup had
+	// a trial_ends_at that nothing acted on — ExpiryCron selects trialing —
+	// so the trial clock #827 started could never ring.
+	//
+	// What still lands here: nothing, on the current paths. The value is kept
+	// because the Stripe checkout webhook's signup → trialing transition and
+	// the reminder ladder's `status IN (signup, trialing)` both still name
+	// it, and because rows written before #827 may hold it. Documented rather than fixed, on
 	// purpose — tesserix-home#582's reasoning applied to this enum
 	// (mark8ly#803, decided 2026-09-07).
 	//
-	// Exactly one thing promotes it: the Stripe
-	// `checkout.session.completed` webhook (`internal/billing/dispatch/handlers.go`).
-	// A tenant who signs up and abandons checkout therefore stays here
-	// indefinitely — and nothing else observes them, because `ExpiryCron`
-	// selects `trialing` and the dunning ladder selects live statuses. Not
-	// trialing, so no trial machinery; not expired, so no retention path;
-	// not converted, so nothing bills them.
+	// One thing promotes it: the Stripe `checkout.session.completed` webhook
+	// (`internal/billing/dispatch/handlers.go`). A row that somehow sits here
+	// is observed by almost nothing — `ExpiryCron` selects `trialing`, so it
+	// is not trialing and gets no trial machinery; not expired, so no
+	// retention path; not converted, so nothing bills it. The reminder ladder
+	// is the one exception: it selects signup AND trialing.
 	//
 	// WHY NOTHING WAS BUILT. Measured on 2026-09-07: `store_subscriptions`
 	// held ZERO rows, and Stripe is deliberately still on the test key
-	// (mark8ly#371, "not yet"), so no tenant can be stuck here yet. An
-	// expiry path or a chase path would be writer code exercised against
-	// zero rows — the failure this milestone already paid for once.
+	// (mark8ly#371, "not yet"). That premise expired the moment #827
+	// backfilled four rows — all of them landed here, and two were weeks past
+	// their trial end with nothing to sweep them. The answer was to stop
+	// creating rows in this state rather than to build a second expiry path
+	// for it.
 	//
 	// WHAT REOPENS IT: real subscribers existing (following the live-key
 	// swap), or an abandonment rate worth chasing. The chase option

--- a/services/marketplace-api/internal/subscription/service.go
+++ b/services/marketplace-api/internal/subscription/service.go
@@ -134,7 +134,24 @@ func (s *Service) Bootstrap(ctx context.Context, in BootstrapInput) (*StoreSubsc
 		TenantID: in.TenantID,
 		StoreID:  in.StoreID,
 		Plan:     PlanTrial,
-		Status:   StatusSignup,
+		// trialing, not signup. §17.2's own trigger for this transition is
+		// "email verified", and the only caller reaches here from onboarding
+		// completion, which cannot happen until the merchant has clicked the
+		// magic link.
+		//
+		// signup would be worse than merely inaccurate. It is documented as a
+		// RESTING STATE that only the Stripe checkout webhook promotes, and
+		// ExpiryCron selects `trialing` — so a row left in signup has a
+		// trial_ends_at that NOTHING acts on. #827 started the clock; this is
+		// what makes it ring. Four backfilled stores sat in exactly that
+		// state, two of them weeks past their end date and invisible to
+		// every sweep.
+		//
+		// trialing is also what the rest of the table expects of these rows:
+		// `trialing → expired (day 90, no card)` describes them precisely,
+		// and `trialing → active (card added)` is where the deferred-charge
+		// flow takes them next.
+		Status: StatusTrialing,
 	}
 	if cur := strings.ToLower(strings.TrimSpace(in.BillingCurrency)); cur != "" {
 		row.BillingCurrency = &cur


### PR DESCRIPTION
`Bootstrap` created every subscription in `signup`. `ExpiryCron` selects `trialing`. So the trial clock #827 started could never ring.

Found because the console's Subscriptions tab showed all four backfilled stores and the Trials tab showed none — the visible symptom of a row in a state no trial machinery observes.

## The contradiction

The transition table names its own trigger:

```go
subscription.StatusSignup: {
    subscription.StatusTrialing: {..., "§17.2 signup → trialing (email verified)"},
}
```

But the only code that performs it is the Stripe `checkout.session.completed` webhook. Onboarding verifies the email by magic link — it cannot complete otherwise — and still left the row in `signup`, where `StatusSignup`'s own doc says:

> a RESTING STATE… nothing else observes them, because `ExpiryCron` selects `trialing`… Not trialing, so no trial machinery.

| consumer | selects | saw those rows |
|---|---|---|
| `ExpiryCron` | `status = 'trialing'` | **no** |
| trial reminders | `status IN ('signup','trialing')` | yes |
| console Trials tab | trialing | **no** |

Two of the four backfilled trials ended on 28 July and 27 August. Nothing would ever have expired them.

## The fix

`Bootstrap` creates `trialing`. Its only caller is the onboarding subscription callback, which runs after email verification — exactly §17.2's stated trigger. It is also what the rest of the table expects of these rows: `trialing → expired (day 90, no card)` describes them precisely, and `trialing → active (card added)` is where the deferred-charge flow takes them next.

`StatusSignup`'s doc is corrected rather than deleted. Its "WHY NOTHING WAS BUILT" note rested on `store_subscriptions` holding zero rows, measured 2026-09-07 — a premise #827's backfill retired the next day. The answer was to stop creating rows in that state, not to build a second expiry path for it.

The Stripe webhook's `signup → trialing` transition still exists and now no-ops on these rows; it already treats `ErrInvalidTransition` as success.

## Test plan

- [x] `gofmt`, `go build`, `go vet ./...` and `-tags integration`, full marketplace-api suite green
- [x] The existing Bootstrap test asserted `signup` and now asserts `trialing`, with the reason in the diff
- [x] New: `TestBootstrap_CreatesARowTheExpiryCronCanSee` fails on `signup` specifically, naming why
- [x] `gitleaks` clean

## Production

Four rows are in `signup` and need flipping to `trialing` after this deploys. Two are past their end date, so the next `ExpiryCron` run (00:15) will mark them `expired` — which is the truthful state and the point of the fix.

**No email is sent.** All four have no billing email, and `notifyExpired` validates the recipient and skips, counting the reason. Checked before proposing this, not after.
