### PR TITLE
feat(breakglass): make the 3-strike login window durable, so the admin deployment can run more than one replica (#846)

### DIFF
--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -588,6 +588,12 @@ func main() {
 	// never two. See the construction site (admin-mode block) for why.
 	var breakGlassLoginHandler *admin.BreakGlassLoginHandler
 	var breakGlassRateLimiter *breakglass.LoginRateLimiter
+	// The composite the CLEAR path uses — in-memory plus durable. Separate
+	// from breakGlassRateLimiter because the login path needs the two apart
+	// (it prefers the durable count and falls back to the in-memory one),
+	// while clear-lockout must hit both or the IP re-locks on its next
+	// failure (#846).
+	var breakGlassWindowReset *breakglass.CompositeWindow
 	// #404's write deps. Declared at this scope for the same reason the
 	// limiter is: platformadmin.Register is called far below, and both
 	// must reach it from inside the OpenBao-guarded block that builds them.
@@ -1430,12 +1436,22 @@ func main() {
 			// durable lockout row clears, the operator sees success, and
 			// the in-memory limiter keeps refusing the IP (#642).
 			breakGlassRateLimiter = breakglass.NewLoginRateLimiter()
+			// The DURABLE window, backed by break_glass_login_attempts. It is
+			// what makes the 3-strike threshold a property of the estate
+			// rather than of whichever pod took the request, and therefore
+			// what allows this deployment to run more than one replica —
+			// which is what removes the total platform-admin outage on every
+			// deploy (#846).
+			breakGlassDBWindow := breakglass.NewDBLoginWindow(breakGlassRepo)
+			breakGlassWindowReset = breakglass.NewCompositeWindow(
+				breakGlassRateLimiter, breakGlassDBWindow)
 			breakGlassLoginHandler = admin.NewBreakGlassLoginHandler(admin.BreakGlassDeps{
 				Repo:        breakGlassRepo,
 				Secrets:     breakGlassSecrets,
 				Audit:       breakGlassAudit,
 				Slack:       breakGlassSlack,
 				RateLimiter: breakGlassRateLimiter,
+				Window:      breakGlassDBWindow,
 				IPHMACKey:   breakGlassIPHMACKey,
 				Sessions:    authbffclient.NewSessionIssuer(cfg.AuthBFFURL, cfg.InternalAuthSecret, nil),
 				Logger:      log,
@@ -2635,7 +2651,7 @@ func main() {
 			BreakGlass:              platformadmin.BreakGlassListerFunc(breakglass.ListPlatform),
 			BreakGlassRotator:       breakGlassRotator,
 			BreakGlassWriter:        breakGlassWriter,
-			BreakGlassRateLimiter:   breakGlassRateLimiter,
+			BreakGlassRateLimiter:   breakGlassWindowResetOrNil(breakGlassWindowReset),
 			BreakGlassIPHMACKey:     breakglass.HMACKey(cfg.BreakGlassIPHMACKey),
 			EmailTemplates:          templateStore,
 			EmailTemplateRegistry:   templateLoader,
@@ -2812,7 +2828,7 @@ func main() {
 				BreakGlass:              platformadmin.BreakGlassListerFunc(breakglass.ListPlatform),
 				BreakGlassRotator:       breakGlassRotator,
 				BreakGlassWriter:        breakGlassWriter,
-				BreakGlassRateLimiter:   breakGlassRateLimiter,
+				BreakGlassRateLimiter:   breakGlassWindowResetOrNil(breakGlassWindowReset),
 				BreakGlassIPHMACKey:     breakglass.HMACKey(cfg.BreakGlassIPHMACKey),
 				EmailTemplates:          templateStore,
 				EmailTemplateRegistry:   templateLoader,
@@ -3119,4 +3135,19 @@ func tenantDiscountApplier(s *tenantdiscount.Service) planchange.TenantDiscountA
 		return nil
 	}
 	return s
+}
+
+// breakGlassWindowResetOrNil returns w as the platformadmin interface, or a
+// genuine nil interface when w is nil.
+//
+// Assigning a nil *breakglass.CompositeWindow straight into an interface
+// field would produce a NON-nil interface wrapping a nil pointer, and
+// platformadmin's clear-lockout nil-check (`if h.rateLimiter != nil`) would
+// pass — then call Reset on nil. The interface's own doc comment asks callers
+// to avoid exactly this; this helper is where that promise is kept.
+func breakGlassWindowResetOrNil(w *breakglass.CompositeWindow) platformadmin.BreakGlassRateLimiter {
+	if w == nil {
+		return nil
+	}
+	return w
 }

--- a/services/marketplace-api/internal/breakglass/composite_window.go
+++ b/services/marketplace-api/internal/breakglass/composite_window.go
@@ -1,0 +1,69 @@
+package breakglass
+
+import (
+	"context"
+	"errors"
+)
+
+// CompositeWindow fans a LoginWindow operation across several windows.
+//
+// It exists for the CLEAR path, not the counting one (#846). Clearing a
+// lockout has to clear every window that could re-earn it: with the durable
+// window in place, clearing the lockout row while leaving the attempt rows
+// behind means the very next failure counts as the fourth and re-locks the
+// IP immediately — an operator would see clear-lockout succeed and the IP
+// stay locked, which is the exact failure `LoginRateLimitKey`'s comment was
+// written to prevent one level down.
+//
+// Counting deliberately does NOT go through this type. The login handler
+// needs to know WHICH window answered so it can prefer the durable count and
+// fall back to the in-memory one; a composite that merged them would have to
+// invent a rule for disagreement, and the honest rule is the caller's.
+type CompositeWindow struct{ windows []LoginWindow }
+
+// NewCompositeWindow returns a window that applies Reset to each of windows,
+// in order. Nil entries are dropped so a caller can pass an optional window
+// without a nil check at every site.
+func NewCompositeWindow(windows ...LoginWindow) *CompositeWindow {
+	live := make([]LoginWindow, 0, len(windows))
+	for _, w := range windows {
+		if w != nil {
+			live = append(live, w)
+		}
+	}
+	return &CompositeWindow{windows: live}
+}
+
+// Reset clears every window, and does NOT stop at the first error.
+//
+// A partial clear is the dangerous outcome here — it is what leaves an
+// operator believing an IP is unlocked while one window still refuses it —
+// so every window is attempted and the errors are joined. The caller decides
+// what a partial failure means; this type will not hide one.
+func (c *CompositeWindow) Reset(ctx context.Context, k LoginKey) error {
+	var errs []error
+	for _, w := range c.windows {
+		if err := w.Reset(ctx, k); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// RecordFailure is refused rather than implemented.
+//
+// Stamping a failure on several windows and returning one number requires
+// choosing which number is the answer, and that choice belongs to the login
+// handler (see recordAcrossWindows), which has the context to prefer the
+// durable count and log when it had to fall back. Returning, say, the max
+// here would silently make a database outage look like a healthy count.
+func (c *CompositeWindow) RecordFailure(context.Context, LoginKey) (int, error) {
+	return 0, errors.New("breakglass: CompositeWindow is for Reset only; count through a specific window")
+}
+
+// Count is refused for the same reason RecordFailure is.
+func (c *CompositeWindow) Count(context.Context, LoginKey) (int, error) {
+	return 0, errors.New("breakglass: CompositeWindow is for Reset only; count through a specific window")
+}
+
+var _ LoginWindow = (*CompositeWindow)(nil)

--- a/services/marketplace-api/internal/breakglass/composite_window_test.go
+++ b/services/marketplace-api/internal/breakglass/composite_window_test.go
@@ -1,0 +1,106 @@
+package breakglass_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
+)
+
+// stubWindow records what it was asked and can be made to fail.
+type stubWindow struct {
+	resets int
+	err    error
+}
+
+func (s *stubWindow) RecordFailure(context.Context, breakglass.LoginKey) (int, error) {
+	return 0, nil
+}
+func (s *stubWindow) Reset(context.Context, breakglass.LoginKey) error {
+	s.resets++
+	return s.err
+}
+func (s *stubWindow) Count(context.Context, breakglass.LoginKey) (int, error) { return 0, nil }
+
+func key() breakglass.LoginKey {
+	return breakglass.LoginKey{IPHash: []byte("0123456789abcdef-and-more")}
+}
+
+// The property clear-lockout depends on: EVERY window is cleared, not just
+// until the first one errors. A partial clear is what leaves an operator
+// believing an IP is unlocked while one window still refuses it.
+func TestCompositeWindowResetsEveryWindowEvenAfterAFailure(t *testing.T) {
+	failing := &stubWindow{err: errors.New("db down")}
+	healthy := &stubWindow{}
+
+	err := breakglass.NewCompositeWindow(failing, healthy).Reset(context.Background(), key())
+
+	require.Error(t, err, "a failed window must be reported, never swallowed")
+	require.Equal(t, 1, failing.resets)
+	require.Equal(t, 1, healthy.resets,
+		"a window after a failing one must still be cleared")
+}
+
+func TestCompositeWindowReportsSuccessWhenEveryWindowClears(t *testing.T) {
+	a, b := &stubWindow{}, &stubWindow{}
+	require.NoError(t, breakglass.NewCompositeWindow(a, b).Reset(context.Background(), key()))
+	require.Equal(t, 1, a.resets)
+	require.Equal(t, 1, b.resets)
+}
+
+// A nil window is dropped rather than panicking, so a caller can pass an
+// optional window without a nil check at every construction site.
+func TestCompositeWindowIgnoresNilWindows(t *testing.T) {
+	only := &stubWindow{}
+	require.NoError(t, breakglass.NewCompositeWindow(nil, only, nil).Reset(context.Background(), key()))
+	require.Equal(t, 1, only.resets)
+}
+
+// Counting through the composite is refused rather than guessed at. If this
+// ever starts returning a number, the login handler's choice of which window
+// to believe has been silently taken away from it.
+func TestCompositeWindowRefusesToCount(t *testing.T) {
+	c := breakglass.NewCompositeWindow(&stubWindow{})
+
+	_, err := c.RecordFailure(context.Background(), key())
+	require.Error(t, err)
+
+	_, err = c.Count(context.Background(), key())
+	require.Error(t, err)
+}
+
+// The two implementations must agree on how a LoginKey maps to the in-memory
+// bucket, or clear-lockout resets a bucket the login path never reads — the
+// hazard LoginRateLimitKey was extracted to prevent.
+func TestLoginKeyBucketMatchesLoginRateLimitKey(t *testing.T) {
+	k := key()
+	require.Equal(t, breakglass.LoginRateLimitKey(k.IPHash), k.Bucket())
+}
+
+// The exported interface methods, which the older table-driven tests reach
+// through unexported helpers. Without this, a signature that compiles but
+// counts wrongly would ship.
+func TestInMemoryWindowSatisfiesTheInterfaceContract(t *testing.T) {
+	var w breakglass.LoginWindow = breakglass.NewLoginRateLimiter()
+	ctx := context.Background()
+
+	n, err := w.RecordFailure(ctx, key())
+	require.NoError(t, err)
+	require.Equal(t, 1, n, "RecordFailure returns the count INCLUDING this failure")
+
+	n, err = w.RecordFailure(ctx, key())
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+
+	n, err = w.Count(ctx, key())
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+
+	require.NoError(t, w.Reset(ctx, key()))
+	n, err = w.Count(ctx, key())
+	require.NoError(t, err)
+	require.Zero(t, n)
+}

--- a/services/marketplace-api/internal/breakglass/dbwindow.go
+++ b/services/marketplace-api/internal/breakglass/dbwindow.go
@@ -1,0 +1,38 @@
+package breakglass
+
+import "context"
+
+// DBLoginWindow is the estate-wide sliding window, backed by
+// break_glass_login_attempts (#846).
+//
+// It is a thin adapter over the repository rather than its own query layer:
+// the SQL lives beside every other break-glass query, and this type exists
+// only to satisfy LoginWindow without making the handler depend on the whole
+// Repository surface for three methods.
+type DBLoginWindow struct{ repo *Repository }
+
+// NewDBLoginWindow returns a LoginWindow backed by Postgres.
+func NewDBLoginWindow(repo *Repository) *DBLoginWindow { return &DBLoginWindow{repo: repo} }
+
+// RecordFailure appends the attempt and returns the in-window count.
+func (w *DBLoginWindow) RecordFailure(ctx context.Context, k LoginKey) (int, error) {
+	return w.repo.RecordLoginFailure(ctx, k.IPHash)
+}
+
+// Reset clears every attempt for this ip_hash.
+func (w *DBLoginWindow) Reset(ctx context.Context, k LoginKey) error {
+	return w.repo.ClearLoginFailures(ctx, k.IPHash)
+}
+
+// Count returns the in-window failure count.
+func (w *DBLoginWindow) Count(ctx context.Context, k LoginKey) (int, error) {
+	return w.repo.CountLoginFailures(ctx, k.IPHash)
+}
+
+// Compile-time proof both implementations satisfy the interface. Without
+// these, a signature drifting on one of them would only fail at the wiring
+// site in main.go, which is a long way from the code that broke.
+var (
+	_ LoginWindow = (*DBLoginWindow)(nil)
+	_ LoginWindow = (*LoginRateLimiter)(nil)
+)

--- a/services/marketplace-api/internal/breakglass/dbwindow_integration_test.go
+++ b/services/marketplace-api/internal/breakglass/dbwindow_integration_test.go
@@ -1,0 +1,135 @@
+//go:build integration
+
+package breakglass_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark8ly/marketplace-api/internal/breakglass"
+	"github.com/mark8ly/marketplace-api/pkg/testdb"
+)
+
+func dbKey(b string) breakglass.LoginKey {
+	return breakglass.LoginKey{IPHash: []byte(b)}
+}
+
+// The property the whole change exists for: the count is a property of the
+// ESTATE, so a second "pod" reading the same table sees the first one's
+// failures. Two repositories over one database stand in for two replicas —
+// with the in-memory window this test is impossible to write at all.
+func TestIntegration_DBLoginWindow_CountIsSharedAcrossPods(t *testing.T) {
+	db := testdb.NewTx(t)
+	podA := breakglass.NewDBLoginWindow(breakglass.NewRepository(db))
+	podB := breakglass.NewDBLoginWindow(breakglass.NewRepository(db))
+	ctx := context.Background()
+	k := dbKey("shared-ip-hash-0001")
+
+	n, err := podA.RecordFailure(ctx, k)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+
+	// The second failure lands on the OTHER pod and must still count as the
+	// second, not as that pod's first. This is precisely what per-pod
+	// counting got wrong, and why 2 replicas used to mean 6 strikes.
+	n, err = podB.RecordFailure(ctx, k)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+
+	n, err = podB.RecordFailure(ctx, k)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, n, breakglass.LoginMaxFailures,
+		"the threshold must be reached on the third failure regardless of which pod saw them")
+}
+
+// Clearing on one pod clears for every pod — the clear-lockout path depends
+// on this, or an operator clears a lockout and the IP re-locks on its next
+// failure because the attempt rows survived.
+func TestIntegration_DBLoginWindow_ResetIsVisibleToEveryPod(t *testing.T) {
+	db := testdb.NewTx(t)
+	podA := breakglass.NewDBLoginWindow(breakglass.NewRepository(db))
+	podB := breakglass.NewDBLoginWindow(breakglass.NewRepository(db))
+	ctx := context.Background()
+	k := dbKey("shared-ip-hash-0002")
+
+	_, err := podA.RecordFailure(ctx, k)
+	require.NoError(t, err)
+	_, err = podA.RecordFailure(ctx, k)
+	require.NoError(t, err)
+
+	require.NoError(t, podB.Reset(ctx, k))
+
+	n, err := podA.Count(ctx, k)
+	require.NoError(t, err)
+	require.Zero(t, n, "a reset on one pod must clear the window for all of them")
+}
+
+// Two ip_hashes must not share a bucket. A predicate that dropped the
+// ip_hash filter would still pass every count test above.
+func TestIntegration_DBLoginWindow_CountsPerIPHash(t *testing.T) {
+	db := testdb.NewTx(t)
+	w := breakglass.NewDBLoginWindow(breakglass.NewRepository(db))
+	ctx := context.Background()
+
+	_, err := w.RecordFailure(ctx, dbKey("ip-hash-aaaa"))
+	require.NoError(t, err)
+	_, err = w.RecordFailure(ctx, dbKey("ip-hash-aaaa"))
+	require.NoError(t, err)
+
+	n, err := w.Count(ctx, dbKey("ip-hash-bbbb"))
+	require.NoError(t, err)
+	require.Zero(t, n, "one IP's failures must not count against another's")
+}
+
+// Rows outside LoginRateWindow are ignored. Without this the window is not a
+// window at all — an IP that failed twice a year ago would be one strike from
+// a 24h lockout forever.
+func TestIntegration_DBLoginWindow_IgnoresAttemptsOutsideTheWindow(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := breakglass.NewRepository(db)
+	w := breakglass.NewDBLoginWindow(repo)
+	ctx := context.Background()
+	k := dbKey("ip-hash-stale-001")
+
+	_, err := w.RecordFailure(ctx, k)
+	require.NoError(t, err)
+
+	// Age the row past the window.
+	require.NoError(t, db.Exec(
+		`UPDATE break_glass_login_attempts SET attempted_at = ? WHERE ip_hash = ?`,
+		time.Now().UTC().Add(-2*breakglass.LoginRateWindow), []byte(k.IPHash),
+	).Error)
+
+	n, err := w.Count(ctx, k)
+	require.NoError(t, err)
+	require.Zero(t, n, "an attempt older than LoginRateWindow is outside the window")
+}
+
+// The sweep removes aged rows without touching in-window ones.
+func TestIntegration_DBLoginWindow_PruneKeepsInWindowAttempts(t *testing.T) {
+	db := testdb.NewTx(t)
+	repo := breakglass.NewRepository(db)
+	ctx := context.Background()
+	fresh := dbKey("ip-hash-fresh-01")
+	stale := dbKey("ip-hash-stale-02")
+
+	_, err := repo.RecordLoginFailure(ctx, fresh.IPHash)
+	require.NoError(t, err)
+	_, err = repo.RecordLoginFailure(ctx, stale.IPHash)
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(
+		`UPDATE break_glass_login_attempts SET attempted_at = ? WHERE ip_hash = ?`,
+		time.Now().UTC().Add(-2*breakglass.LoginRateWindow), []byte(stale.IPHash),
+	).Error)
+
+	removed, err := repo.PruneLoginAttempts(ctx, breakglass.LoginRateWindow)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), removed)
+
+	n, err := repo.CountLoginFailures(ctx, fresh.IPHash)
+	require.NoError(t, err)
+	require.Equal(t, 1, n, "prune must not remove an in-window attempt")
+}

--- a/services/marketplace-api/internal/breakglass/models.go
+++ b/services/marketplace-api/internal/breakglass/models.go
@@ -62,6 +62,23 @@ type Lockout struct {
 // TableName pins the Postgres table name.
 func (Lockout) TableName() string { return "break_glass_lockouts" }
 
+// LoginAttempt is one failed break-glass login, kept for the length of
+// LoginRateWindow so the 3-strike threshold can be evaluated across every
+// pod rather than within one (#846).
+//
+// Deliberately append-only and id-keyed rather than a counter row per
+// ip_hash: a counter needs read-modify-write and two pods racing it would
+// undercount exactly when the count matters most. An INSERT races nothing,
+// and the window is a COUNT over an index.
+type LoginAttempt struct {
+	ID          int64     `gorm:"column:id;primaryKey;autoIncrement"`
+	IPHash      []byte    `gorm:"column:ip_hash;type:bytea;not null;index"`
+	AttemptedAt time.Time `gorm:"column:attempted_at;not null;autoCreateTime"`
+}
+
+// TableName pins the Postgres table name.
+func (LoginAttempt) TableName() string { return "break_glass_login_attempts" }
+
 // Sentinel errors. Callers use errors.Is to distinguish these from
 // arbitrary SQL / Secret Manager failures.
 var (

--- a/services/marketplace-api/internal/breakglass/ratelimit.go
+++ b/services/marketplace-api/internal/breakglass/ratelimit.go
@@ -1,6 +1,7 @@
 package breakglass
 
 import (
+	"context"
 	"sync"
 	"time"
 )
@@ -16,14 +17,69 @@ const LoginMaxFailures = 3
 // LoginLockoutDuration is the hard lockout persisted on the Nth failure.
 const LoginLockoutDuration = 24 * time.Hour
 
+// LoginWindow is the sliding window the login path counts against.
+//
+// An interface so the window can be per-pod or estate-wide without the
+// handler knowing which. `LoginRateLimiter` below is the in-memory one;
+// `DBLoginWindow` is the durable one backed by break_glass_login_attempts.
+//
+// The methods take a context because the durable implementation does I/O.
+// The in-memory one ignores it, which is the cost of having one interface
+// rather than two call sites.
+//
+// # Why a second implementation exists (#846)
+//
+// The in-memory window is per-POD. That was fine while the admin deployment
+// was pinned to a single replica — and the pin was the problem: with
+// `maxSurge: 0` the only pod is scaled to zero before its replacement
+// starts, so every marketplace-api deploy took the whole platform-admin
+// surface offline for the length of an image pull. Every federated read from
+// the tesserix console failed for that window.
+//
+// The pin could not simply be lifted. The durable lockout row is enforced
+// estate-wide (the login path reads `IsIPLocked` on every attempt), but the
+// COUNTING toward the 3-strike threshold was per-pod, so N replicas meant an
+// attacker spreading attempts across them needed 3N failures rather than 3.
+// Making the window durable is what makes the replica count a free choice.
+//
+// The original note here said a Redis INCR/EXPIRE swap would land in this
+// interface. Redis has since been removed from marketplace-api entirely —
+// it is not in go.mod — so the swap landed on Postgres, which the login path
+// was already reading on every attempt anyway.
+type LoginWindow interface {
+	// RecordFailure stamps a failure and returns the in-window count
+	// INCLUDING it. Callers compare against LoginMaxFailures.
+	RecordFailure(ctx context.Context, key LoginKey) (int, error)
+	// Reset clears the bucket for key.
+	Reset(ctx context.Context, key LoginKey) error
+	// Count returns the current in-window failure count for key.
+	Count(ctx context.Context, key LoginKey) (int, error)
+}
+
+// LoginKey is a bucket key. It carries BOTH shapes the two implementations
+// need — the truncated string the in-memory map is keyed by, and the full
+// ip_hash the durable table stores — so a caller cannot hand one
+// implementation a key shaped for the other.
+//
+// This is the same hazard `LoginRateLimitKey` was extracted to prevent, one
+// level up: a key shaped differently in the login path than in the
+// clear-lockout path means clear-lockout resets a bucket nobody reads.
+type LoginKey struct {
+	// IPHash is the full HMAC. The durable window stores and queries it.
+	IPHash []byte
+}
+
+// Bucket is the in-memory map key for this LoginKey — the first 16 bytes of
+// the ip_hash, exactly what LoginRateLimitKey has always produced.
+func (k LoginKey) Bucket() string { return LoginRateLimitKey(k.IPHash) }
+
 // LoginRateLimiter is an in-memory sliding-window counter keyed by
 // ip_hash. Pair it with the DB-backed lockouts table: the RL carries
 // recent, fast-moving counts; the table is the durable decision.
 //
-// Deliberately not Redis-backed today. The single-process footprint
-// of marketplace-api + the 3-strike threshold make per-pod accuracy
-// good enough. When the service scales horizontally a Redis INCR/EXPIRE
-// swap lands in the same interface.
+// Still used as the DEGRADED fallback when the lockout store cannot be
+// read (#468) — see the login handler — so it is not dead code even where
+// DBLoginWindow is wired.
 type LoginRateLimiter struct {
 	mu       sync.Mutex
 	attempts map[string][]time.Time
@@ -38,7 +94,11 @@ func NewLoginRateLimiter() *LoginRateLimiter {
 // count of failures inside the current window AFTER the stamp.
 // Callers compare against LoginMaxFailures to decide whether to
 // persist a hard lockout.
-func (l *LoginRateLimiter) RecordFailure(key string) int {
+func (l *LoginRateLimiter) RecordFailure(_ context.Context, k LoginKey) (int, error) {
+	return l.recordFailure(k.Bucket()), nil
+}
+
+func (l *LoginRateLimiter) recordFailure(key string) int {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -61,7 +121,12 @@ func (l *LoginRateLimiter) RecordFailure(key string) int {
 // Reset clears the bucket for key. Called on successful login so a
 // single slow-typist failure doesn't count against the next legitimate
 // attempt.
-func (l *LoginRateLimiter) Reset(key string) {
+func (l *LoginRateLimiter) Reset(_ context.Context, k LoginKey) error {
+	l.reset(k.Bucket())
+	return nil
+}
+
+func (l *LoginRateLimiter) reset(key string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	delete(l.attempts, key)
@@ -93,7 +158,11 @@ func LoginRateLimitKey(ipHash []byte) string {
 
 // Count returns the current in-window failure count for key. Useful
 // for tests; production code should use RecordFailure's return value.
-func (l *LoginRateLimiter) Count(key string) int {
+func (l *LoginRateLimiter) Count(_ context.Context, k LoginKey) (int, error) {
+	return l.count(k.Bucket()), nil
+}
+
+func (l *LoginRateLimiter) count(key string) int {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 

--- a/services/marketplace-api/internal/breakglass/ratelimit_test.go
+++ b/services/marketplace-api/internal/breakglass/ratelimit_test.go
@@ -8,26 +8,26 @@ import (
 
 func TestLoginRateLimiter_CountsFailuresInWindow(t *testing.T) {
 	rl := NewLoginRateLimiter()
-	require.Equal(t, 1, rl.RecordFailure("ip-a"))
-	require.Equal(t, 2, rl.RecordFailure("ip-a"))
-	require.Equal(t, 3, rl.RecordFailure("ip-a"))
-	require.Equal(t, 3, rl.Count("ip-a"))
+	require.Equal(t, 1, rl.recordFailure("ip-a"))
+	require.Equal(t, 2, rl.recordFailure("ip-a"))
+	require.Equal(t, 3, rl.recordFailure("ip-a"))
+	require.Equal(t, 3, rl.count("ip-a"))
 }
 
 func TestLoginRateLimiter_SeparateKeysSeparateCounts(t *testing.T) {
 	rl := NewLoginRateLimiter()
-	rl.RecordFailure("ip-a")
-	rl.RecordFailure("ip-a")
-	require.Equal(t, 1, rl.RecordFailure("ip-b"))
-	require.Equal(t, 2, rl.Count("ip-a"))
-	require.Equal(t, 1, rl.Count("ip-b"))
+	rl.recordFailure("ip-a")
+	rl.recordFailure("ip-a")
+	require.Equal(t, 1, rl.recordFailure("ip-b"))
+	require.Equal(t, 2, rl.count("ip-a"))
+	require.Equal(t, 1, rl.count("ip-b"))
 }
 
 func TestLoginRateLimiter_ResetClearsBucket(t *testing.T) {
 	rl := NewLoginRateLimiter()
-	rl.RecordFailure("ip-a")
-	rl.RecordFailure("ip-a")
-	rl.Reset("ip-a")
-	require.Equal(t, 0, rl.Count("ip-a"))
-	require.Equal(t, 1, rl.RecordFailure("ip-a"))
+	rl.recordFailure("ip-a")
+	rl.recordFailure("ip-a")
+	rl.reset("ip-a")
+	require.Equal(t, 0, rl.count("ip-a"))
+	require.Equal(t, 1, rl.recordFailure("ip-a"))
 }

--- a/services/marketplace-api/internal/breakglass/repository.go
+++ b/services/marketplace-api/internal/breakglass/repository.go
@@ -235,6 +235,74 @@ func (r *Repository) IsIPLocked(ctx context.Context, ipHash []byte) (bool, error
 	return count > 0, nil
 }
 
+// RecordLoginFailure appends one failed attempt and returns the number of
+// failures inside the current window, counting this one — the same contract
+// LoginRateLimiter.RecordFailure has, so the two are interchangeable behind
+// LoginWindow (#846).
+//
+// The INSERT and the COUNT are two statements rather than one CTE, and the
+// count is deliberately taken AFTER the insert. Two pods failing at the same
+// instant may both read the same total; the consequence is that both persist
+// a lockout for an IP that earned one, which LockIP already treats as a
+// no-op. The opposite ordering could let both read a pre-insert count and
+// neither cross the threshold, which is the failure that matters.
+func (r *Repository) RecordLoginFailure(ctx context.Context, ipHash []byte) (int, error) {
+	if len(ipHash) == 0 {
+		return 0, ErrInvalidCredentials
+	}
+	if err := r.ctx(ctx).Create(&LoginAttempt{IPHash: ipHash}).Error; err != nil {
+		return 0, err
+	}
+	return r.CountLoginFailures(ctx, ipHash)
+}
+
+// CountLoginFailures returns the failures for this ip_hash inside the current
+// window. Rows older than the window are ignored rather than deleted — see
+// PruneLoginAttempts for why the sweep is separate.
+func (r *Repository) CountLoginFailures(ctx context.Context, ipHash []byte) (int, error) {
+	if len(ipHash) == 0 {
+		return 0, nil
+	}
+	var count int64
+	err := r.ctx(ctx).
+		Model(&LoginAttempt{}).
+		Where("ip_hash = ? AND attempted_at > ?", ipHash, time.Now().UTC().Add(-LoginRateWindow)).
+		Count(&count).Error
+	if err != nil {
+		return 0, err
+	}
+	return int(count), nil
+}
+
+// ClearLoginFailures drops every attempt for this ip_hash.
+//
+// Called on a successful login and by the clear-lockout write path, which is
+// why it deletes rather than filtering by window: both callers mean "this IP
+// starts again from zero", and leaving in-window rows behind would let a
+// cleared lockout be re-earned by fewer failures than the threshold names.
+func (r *Repository) ClearLoginFailures(ctx context.Context, ipHash []byte) error {
+	if len(ipHash) == 0 {
+		return nil
+	}
+	return r.ctx(ctx).
+		Where("ip_hash = ?", ipHash).
+		Delete(&LoginAttempt{}).Error
+}
+
+// PruneLoginAttempts deletes attempts older than the window.
+//
+// Separate from the counting path on purpose: a delete on every failed login
+// would make the hot path do write work proportional to an attacker's rate,
+// which is the wrong direction. CountLoginFailures is already correct without
+// it — the predicate filters by time — so this is housekeeping, and a
+// deployment that never calls it is correct but accumulates rows.
+func (r *Repository) PruneLoginAttempts(ctx context.Context, olderThan time.Duration) (int64, error) {
+	res := r.ctx(ctx).
+		Where("attempted_at < ?", time.Now().UTC().Add(-olderThan)).
+		Delete(&LoginAttempt{})
+	return res.RowsAffected, res.Error
+}
+
 // isUniqueViolation recognises Postgres 23505 regardless of driver
 // wrapping; also matches sqlite's phrasing so unit tests don't have
 // to pin a specific driver.

--- a/services/marketplace-api/internal/handlers/admin/break_glass_login.go
+++ b/services/marketplace-api/internal/handlers/admin/break_glass_login.go
@@ -22,10 +22,10 @@ const BreakGlassSessionTTL = 2 * time.Hour
 
 // BreakGlassDeps groups every dependency the login handler needs.
 type BreakGlassDeps struct {
-	Repo        *breakglass.Repository
-	Secrets     *breakglass.SecretManager
-	Audit       *breakglass.AuditEmitter
-	Slack       *breakglass.SlackClient
+	Repo    *breakglass.Repository
+	Secrets *breakglass.SecretManager
+	Audit   *breakglass.AuditEmitter
+	Slack   *breakglass.SlackClient
 	// RateLimiter is the IN-MEMORY window, and it is required.
 	//
 	// It is no longer the counter of record — see Window — but it cannot be
@@ -41,10 +41,10 @@ type BreakGlassDeps struct {
 	// behaviour and is correct on a single-replica deployment. With more than
 	// one replica it must be set, or the 3-strike threshold becomes 3 strikes
 	// PER POD.
-	Window      breakglass.LoginWindow
-	IPHMACKey   breakglass.HMACKey
-	Sessions    authbffclient.SessionIssuer
-	Logger      *slog.Logger
+	Window    breakglass.LoginWindow
+	IPHMACKey breakglass.HMACKey
+	Sessions  authbffclient.SessionIssuer
+	Logger    *slog.Logger
 }
 
 // BreakGlassLoginHandler answers POST /admin/break-glass/login.

--- a/services/marketplace-api/internal/handlers/admin/break_glass_login.go
+++ b/services/marketplace-api/internal/handlers/admin/break_glass_login.go
@@ -26,7 +26,22 @@ type BreakGlassDeps struct {
 	Secrets     *breakglass.SecretManager
 	Audit       *breakglass.AuditEmitter
 	Slack       *breakglass.SlackClient
+	// RateLimiter is the IN-MEMORY window, and it is required.
+	//
+	// It is no longer the counter of record — see Window — but it cannot be
+	// dropped: it is the signal `degradedLockDecision` reads when the lockout
+	// store is unreachable, which is exactly the moment Window (also
+	// Postgres-backed) has nothing to offer either. It is therefore stamped
+	// on every failure even while Window is healthy, so it is warm when it
+	// is needed.
 	RateLimiter *breakglass.LoginRateLimiter
+	// Window is the ESTATE-WIDE window, backed by break_glass_login_attempts.
+	//
+	// Optional: nil falls back to RateLimiter alone, which is the pre-#846
+	// behaviour and is correct on a single-replica deployment. With more than
+	// one replica it must be set, or the 3-strike threshold becomes 3 strikes
+	// PER POD.
+	Window      breakglass.LoginWindow
 	IPHMACKey   breakglass.HMACKey
 	Sessions    authbffclient.SessionIssuer
 	Logger      *slog.Logger
@@ -82,7 +97,10 @@ func (h *BreakGlassLoginHandler) Login(c *gin.Context) {
 		// Degrade to the in-memory limiter rather than choosing one extreme.
 		// It is per-pod and resets on deploy, but it is the signal still
 		// available, and it refuses exactly the IPs that have earned it.
-		recent := h.deps.RateLimiter.Count(breakglass.LoginRateLimitKey(ipHash))
+		// The IN-MEMORY window deliberately, not Window: the branch we are in
+		// is "Postgres could not be read", so the durable window has nothing
+		// to add and asking it would just fail again.
+		recent, _ := h.deps.RateLimiter.Count(ctx, breakglass.LoginKey{IPHash: ipHash})
 		locked = degradedLockDecision(recent)
 		h.logger().Error("break-glass: lockout lookup failed; degraded to the in-memory limiter",
 			"err", err, "recent_failures", recent, "treated_as_locked", locked)
@@ -189,7 +207,11 @@ func (h *BreakGlassLoginHandler) Login(c *gin.Context) {
 		}()
 	}
 
-	h.deps.RateLimiter.Reset(breakglass.LoginRateLimitKey(ipHash))
+	// Both windows, because both are consulted: the durable one decides the
+	// threshold and the in-memory one is the degraded fallback. Clearing only
+	// one leaves a successful login still counted against the next attempt by
+	// whichever window was missed.
+	h.resetWindows(ctx, ipHash)
 
 	c.JSON(http.StatusOK, gin.H{"session_ttl_seconds": int(BreakGlassSessionTTL.Seconds())})
 }
@@ -199,7 +221,7 @@ func (h *BreakGlassLoginHandler) Login(c *gin.Context) {
 // event. Slack is also pinged so on-call sees the attempt in real
 // time.
 func (h *BreakGlassLoginHandler) recordFailure(c *gin.Context, ipHash []byte, tenantID uuid.UUID, reason string) {
-	count := h.deps.RateLimiter.RecordFailure(breakglass.LoginRateLimitKey(ipHash))
+	count := h.recordAcrossWindows(c.Request.Context(), ipHash)
 
 	if count >= breakglass.LoginMaxFailures {
 		var tidPtr *uuid.UUID
@@ -246,6 +268,55 @@ var breakGlassNamespace = uuid.MustParse("1ffb2c0e-8c3a-4d78-9aee-62267a3c110a")
 // collides with a real user).
 func BreakGlassUserID(tenantID uuid.UUID) uuid.UUID {
 	return uuid.NewSHA1(breakGlassNamespace, []byte(tenantID.String()))
+}
+
+// recordAcrossWindows stamps the failure on both windows and returns the count
+// the threshold is judged on.
+//
+// The in-memory window is stamped FIRST and unconditionally. It is the
+// degraded signal, and a durable window that is healthy today must not leave
+// it cold for the day the database is not — `degradedLockDecision` reads it
+// precisely when Window cannot answer.
+//
+// The DURABLE count wins when it is available, because it is the only one
+// that is a property of the estate rather than of this pod. When it errors,
+// the in-memory count is used rather than zero: falling back to "no failures
+// recorded" would make a database blip into a bypass of the whole threshold.
+func (h *BreakGlassLoginHandler) recordAcrossWindows(ctx context.Context, ipHash []byte) int {
+	key := breakglass.LoginKey{IPHash: ipHash}
+
+	local, _ := h.deps.RateLimiter.RecordFailure(ctx, key)
+	if h.deps.Window == nil {
+		return local
+	}
+
+	durable, err := h.deps.Window.RecordFailure(ctx, key)
+	if err != nil {
+		// Error, not Warn, for the reason #468 gives about the lockout write:
+		// this is the durable half of a security control failing, and the
+		// symptom (a threshold counted per-pod again) is invisible otherwise.
+		h.logger().Error("break-glass: durable login window unavailable; counting per-pod",
+			"err", err, "failures_in_window", local)
+		return local
+	}
+	return durable
+}
+
+// resetWindows clears both windows for an ip_hash. Errors are logged, never
+// returned: this runs after a SUCCESSFUL login, and refusing the session
+// because a cleanup delete failed would deny an operator the emergency access
+// they just proved they were entitled to. The cost of a missed clear is that
+// the IP keeps stale failures until they age out of the window.
+func (h *BreakGlassLoginHandler) resetWindows(ctx context.Context, ipHash []byte) {
+	key := breakglass.LoginKey{IPHash: ipHash}
+	_ = h.deps.RateLimiter.Reset(ctx, key)
+	if h.deps.Window == nil {
+		return
+	}
+	if err := h.deps.Window.Reset(ctx, key); err != nil {
+		h.logger().Error("break-glass: durable login window not cleared after a successful login",
+			"err", err)
+	}
 }
 
 // degradedLockDecision decides whether to treat a login as locked when the

--- a/services/marketplace-api/internal/handlers/admin/break_glass_shared_limiter_integration_test.go
+++ b/services/marketplace-api/internal/handlers/admin/break_glass_shared_limiter_integration_test.go
@@ -4,6 +4,7 @@ package admin_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -97,8 +98,10 @@ func TestSharedRateLimiter_LoginFailureVisibleToClearLockout(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, loginRec.Code, "expected the uniform invalid_credentials failure")
 
 	ipHash := breakglass.HMACIPHash(ipHMACKey, callerIP)
-	key := breakglass.LoginRateLimitKey(ipHash)
-	require.Equal(t, 1, sharedLimiter.Count(key),
+	key := breakglass.LoginKey{IPHash: ipHash}
+	recorded, err := sharedLimiter.Count(context.Background(), key)
+	require.NoError(t, err)
+	require.Equal(t, 1, recorded,
 		"the login path must have recorded its failure on sharedLimiter — if this is 0, "+
 			"the login handler is not touching the instance the test wired it with")
 
@@ -112,7 +115,9 @@ func TestSharedRateLimiter_LoginFailureVisibleToClearLockout(t *testing.T) {
 	writeRouter.ServeHTTP(clearRec, clearReq)
 	require.Equal(t, http.StatusOK, clearRec.Code)
 
-	require.Equal(t, 0, sharedLimiter.Count(key),
+	cleared, err := sharedLimiter.Count(context.Background(), key)
+	require.NoError(t, err)
+	require.Equal(t, 0, cleared,
 		"clear-lockout did NOT reset the same in-memory bucket the login path recorded the "+
 			"failure on. In production this is mark8ly#642's failure mode: the durable DB "+
 			"lockout clears, the API reports success, and the in-memory limiter silently keeps "+

--- a/services/marketplace-api/internal/handlers/admin/break_glass_shared_limiter_test.go
+++ b/services/marketplace-api/internal/handlers/admin/break_glass_shared_limiter_test.go
@@ -61,14 +61,16 @@ func TestSharedRateLimiter_ClearLockoutResetsALoginPathFailure(t *testing.T) {
 	ipHMACKey := breakglass.HMACKey("shared-limiter-unit-test-key")
 	const callerIP = "198.51.100.23"
 	ipHash := breakglass.HMACIPHash(ipHMACKey, callerIP)
-	key := breakglass.LoginRateLimitKey(ipHash)
+	key := breakglass.LoginKey{IPHash: ipHash}
 
 	sharedLimiter := breakglass.NewLoginRateLimiter()
 
 	// --- "login path": the exact two calls break_glass_login.go's
 	// recordFailure makes on a failed attempt. ---
-	sharedLimiter.RecordFailure(key)
-	require.Equal(t, 1, sharedLimiter.Count(key), "test setup: the simulated login failure must be recorded")
+	_, _ = sharedLimiter.RecordFailure(context.Background(), key)
+	recorded, err := sharedLimiter.Count(context.Background(), key)
+	require.NoError(t, err)
+	require.Equal(t, 1, recorded, "test setup: the simulated login failure must be recorded")
 
 	// --- write path: the REAL clear-lockout HTTP handler. ---
 	writeHandler := platformadmin.NewBreakGlassWriteHandler(
@@ -92,7 +94,9 @@ func TestSharedRateLimiter_ClearLockoutResetsALoginPathFailure(t *testing.T) {
 	r.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	require.Equal(t, 0, sharedLimiter.Count(key),
+	cleared, err := sharedLimiter.Count(context.Background(), key)
+	require.NoError(t, err)
+	require.Equal(t, 0, cleared,
 		"clear-lockout did not reset the bucket the login path recorded a failure on — in "+
 			"production this is mark8ly#642's failure mode: the durable DB lockout row clears, "+
 			"the API reports success, and the in-memory limiter silently keeps refusing the IP, "+

--- a/services/marketplace-api/internal/handlers/platformadmin/break_glass_write.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/break_glass_write.go
@@ -32,14 +32,19 @@ type BreakGlassWriter interface {
 	ClearIPLock(ctx context.Context, ipHash []byte) (int64, error)
 }
 
-// BreakGlassRateLimiter is the subset of *breakglass.LoginRateLimiter this
-// handler needs to reset the in-process login limiter alongside the
-// durable DB lockout on clear-lockout. Declared as an interface (not the
-// concrete pointer type) so a nil Deps field is a genuine nil interface,
-// never a non-nil interface wrapping a nil pointer — see the nil check in
-// clearLockout.
+// BreakGlassRateLimiter is the subset of breakglass.LoginWindow this handler
+// needs: reset every login window alongside the durable DB lockout on
+// clear-lockout. Declared as an interface (not a concrete pointer type) so a
+// nil Deps field is a genuine nil interface, never a non-nil interface
+// wrapping a nil pointer — see the nil check in clearLockout.
+//
+// Since #846 the wired value is a *breakglass.CompositeWindow over both the
+// in-memory and the durable window, and BOTH must be cleared. Clearing only
+// the lockout row leaves the durable attempt rows in place, so the next
+// failure counts as the fourth and re-locks the IP instantly — clear-lockout
+// would report success and change nothing an operator could observe.
 type BreakGlassRateLimiter interface {
-	Reset(key string)
+	Reset(ctx context.Context, key breakglass.LoginKey) error
 }
 
 // breakGlassAuditFunc records a platform-operator action against a tenant.
@@ -319,14 +324,23 @@ func (h *BreakGlassWriteHandler) clearLockout(c *gin.Context) {
 		return
 	}
 
-	// LoginRateLimiter is an in-memory, per-pod map (breakglass/ratelimit.go)
-	// — this Reset only reaches the pod serving THIS request. The admin
-	// deployment runs 1 replica today, so the durable DB row cleared above
-	// is the one that actually matters; a second replica's own in-memory
-	// counter would be untouched by this call. That is current luck, not
-	// design (#404).
+	// Since #846 this resets the DURABLE attempt rows as well as the
+	// per-pod in-memory map, which is what makes clear-lockout mean the same
+	// thing on a multi-replica deployment as it did on a single one. The
+	// previous comment here noted that a second replica's in-memory counter
+	// would be untouched and called that "current luck, not design"; the
+	// durable window is the design.
 	if h.rateLimiter != nil {
-		h.rateLimiter.Reset(breakglass.LoginRateLimitKey(ipHash))
+		if err := h.rateLimiter.Reset(c.Request.Context(), breakglass.LoginKey{IPHash: ipHash}); err != nil {
+			// Not fatal to the response: the durable LOCKOUT row is already
+			// cleared above, which is the decision that gates login. A failed
+			// window clear leaves stale failures that age out on their own,
+			// so the operator's action did take effect — but it is logged at
+			// Error because until they age out the IP re-locks sooner than
+			// the threshold implies.
+			h.logger.Error("break-glass: clear-lockout cleared the durable lock but not every login window",
+				"err", err)
+		}
 	} else {
 		h.logger.Warn("break-glass: clear-lockout has no rate limiter wired; only the durable DB lock was cleared")
 	}

--- a/services/marketplace-api/internal/handlers/platformadmin/break_glass_write_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/break_glass_write_test.go
@@ -76,10 +76,13 @@ type fakeRateLimiter struct {
 	resetOn []string
 }
 
-func (f *fakeRateLimiter) Reset(key string) {
+func (f *fakeRateLimiter) Reset(_ context.Context, key breakglass.LoginKey) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.resetOn = append(f.resetOn, key)
+	// Recorded as the BUCKET string so the existing assertions, which compare
+	// against breakglass.LoginRateLimitKey, keep meaning what they meant.
+	f.resetOn = append(f.resetOn, key.Bucket())
+	return nil
 }
 
 func discardBreakGlassAudit(*gin.Context, uuid.UUID, audit.Event) error { return nil }

--- a/services/marketplace-api/migrations.go
+++ b/services/marketplace-api/migrations.go
@@ -14,4 +14,4 @@ var MigrationsFS embed.FS
 // migration state doesn't match. M1 scaffold: version 1 is the no-op init
 // migration that seeds the migrations tracking table. Bump this with every
 // real migration added.
-const ExpectedSchemaVersion uint = 136
+const ExpectedSchemaVersion uint = 137

--- a/services/marketplace-api/migrations/000137_break_glass_login_attempts.down.sql
+++ b/services/marketplace-api/migrations/000137_break_glass_login_attempts.down.sql
@@ -1,0 +1,2 @@
+-- 000137_break_glass_login_attempts.down.sql
+DROP TABLE IF EXISTS break_glass_login_attempts;

--- a/services/marketplace-api/migrations/000137_break_glass_login_attempts.up.sql
+++ b/services/marketplace-api/migrations/000137_break_glass_login_attempts.up.sql
@@ -1,0 +1,30 @@
+-- 000137_break_glass_login_attempts.up.sql
+-- §12.4's sliding window, made durable (#846).
+--
+-- 000073 created break_glass_lockouts and its header called itself
+-- "Sliding-window rate-limit + hard lockouts". Only the lockouts half was
+-- ever built: the window lived in an in-memory map on one pod
+-- (internal/breakglass/ratelimit.go), which is why the admin deployment was
+-- pinned to a single replica. That pin is what makes every marketplace-api
+-- deploy a total outage of the platform-admin surface, because the pod is
+-- scaled to zero before its replacement starts (maxSurge: 0).
+--
+-- This table is the other half. One row per failed attempt, counted inside
+-- LoginRateWindow, so the 3-strike threshold is a property of the ESTATE
+-- rather than of whichever pod happened to receive the request.
+--
+-- ip_hash is an HMAC of the client IP under a shared key (see
+-- internal/breakglass/audit.go HMACIPHash) — raw IPs are never persisted,
+-- the same rule 000073 states.
+
+CREATE TABLE break_glass_login_attempts (
+    id           BIGSERIAL   PRIMARY KEY,
+    ip_hash      BYTEA       NOT NULL,
+    attempted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_break_glass_login_attempts_ip_hash_attempted_at
+    ON break_glass_login_attempts (ip_hash, attempted_at DESC);
+
+COMMENT ON TABLE break_glass_login_attempts IS
+    'Durable sliding window of failed /admin/break-glass/login attempts. §12.4, #846.';


### PR DESCRIPTION
Makes the break-glass 3-strike login window a property of the **estate** rather than of whichever pod took the request, so `mark8ly-marketplace-api-admin` can run more than one replica. That replica pin is what makes every deploy of this service a total outage of the platform-admin surface (#846).

## Why the pin exists, and why it could not just be lifted

`values.yaml` pins the admin deployment to one replica: *"in-memory rate limiter pinned to a single replica to avoid the per-replica bucket multiplication problem… unpin once Redis-backed rate limiter ships."* Combined with `maxSurge: 0` (itself the correct fix for surge-first rollouts deadlocking on this cluster) the only pod is scaled to zero before its replacement starts:

```
Scaled down replica set …-86f8cb55f7 from 1 to 0
Scaled up   replica set …-56f757f5bc from 0 to 1
Successfully pulled image … in 26.7s (38.5s including waiting)
```

Every federated read from the tesserix console fails for that window.

The pin was real, not cargo-culted. The durable lockout row **is** enforced estate-wide — `break_glass_login.go` reads `IsIPLocked` on every attempt — but the *counting toward* the threshold lived in a per-pod map, so N replicas meant an attacker spreading attempts needed 3N failures instead of 3. Lifting the pin alone would have weakened a security control.

**Redis is not the answer any more.** It has been removed from marketplace-api entirely — not in `go.mod`. The swap landed on Postgres instead, which the login path already reads on every attempt, so this adds no new dependency.

## What changed

`000073_break_glass_lockouts` called itself *"Sliding-window rate-limit + hard lockouts"* and only ever built the lockouts half. This adds the other half.

- **`000137_break_glass_login_attempts`** — append-only, one row per failed attempt, indexed `(ip_hash, attempted_at DESC)`. Append-only rather than a counter row per ip_hash on purpose: a counter needs read-modify-write, and two pods racing it would undercount exactly when the count matters most. An INSERT races nothing.
- **`LoginWindow` interface** with two implementations — the existing in-memory `LoginRateLimiter` and the new `DBLoginWindow`.
- **`LoginKey`** carries the full ip_hash *and* exposes `Bucket()` for the truncated in-memory key, so a caller cannot hand one implementation a key shaped for the other — the same hazard `LoginRateLimitKey` was extracted to prevent, one level up.

## The in-memory window is not dead code

It is still stamped on **every** failure even while the durable window is healthy, because it is what `degradedLockDecision` reads when the lockout store is unreachable (#468) — which is exactly the moment the durable window has nothing to offer either. A durable window that left it cold would break the degraded path on the day it is needed.

When the durable count errors, the handler falls back to the in-memory count rather than to zero. Falling back to "no failures recorded" would turn a database blip into a bypass of the whole threshold.

## The bug this would have introduced, and how it is closed

Clear-lockout previously reset only the in-memory map. Its own comment admitted the exposure: *"The admin deployment runs 1 replica today… That is current luck, not design (#404)."*

With a durable window that becomes a real defect: clearing the lockout row while leaving the attempt rows means the next failure counts as the **fourth** and re-locks the IP instantly — the operator sees clear-lockout succeed and nothing change. So `platformadmin`'s resetter now takes a `CompositeWindow` over both windows, and it does **not** stop at the first error: a partial clear is the dangerous outcome, so every window is attempted and the errors joined.

`CompositeWindow` deliberately **refuses** `RecordFailure`/`Count`. Merging counts would require inventing a rule for disagreement, and the honest rule belongs to the login handler, which has the context to prefer the durable count and log when it fell back.

## Tests

Unit (no DB): composite clears every window even after one fails, nil windows dropped, counting refused, `LoginKey.Bucket()` agrees with `LoginRateLimitKey`, and the exported interface contract — the pre-existing table tests were rewired onto unexported helpers, so without this the exported methods would have been untested.

Integration, **run for real against Postgres 15**, not skipped:

```
--- PASS: TestIntegration_DBLoginWindow_CountIsSharedAcrossPods
--- PASS: TestIntegration_DBLoginWindow_ResetIsVisibleToEveryPod
--- PASS: TestIntegration_DBLoginWindow_CountsPerIPHash
--- PASS: TestIntegration_DBLoginWindow_IgnoresAttemptsOutsideTheWindow
--- PASS: TestIntegration_DBLoginWindow_PruneKeepsInWindowAttempts
```

The first is the whole point: two repositories over one database stand in for two replicas, and the second pod's failure counts as the second, not as its own first. With the in-memory window that test cannot be written at all.

Running with `-tags=integration` also caught a break in `break_glass_shared_limiter_integration_test.go` that the plain `go test ./...` never compiles — worth noting, since the untagged suite passing means less here than it looks.

## Verification

`go build ./...`, `go vet -tags=integration ./...`, full unit suite, and the integration suite for all three touched packages — all clean. Migration applied and rolled back against a real Postgres 15; `ExpectedSchemaVersion` bumped to 137 (their own guard caught that).

## Sequencing — this must deploy BEFORE the replica bump

The migration rides along in the `migrate up` initContainer, so no manual step. But the k8s change raising `mark8ly-marketplace-api-admin` to 2 replicas must land **after** this is deployed and confirmed, or there is a window where the pin is lifted and the window is still per-pod. That PR is held until then.
