### PR TITLE
feat(trials): let the console ask for every trial, including ones already ended (#827)

### DIFF
--- a/services/marketplace-api/internal/billing/trial/expiring.go
+++ b/services/marketplace-api/internal/billing/trial/expiring.go
@@ -66,7 +66,31 @@ type ListOptions struct {
 	// not be read as the expiry machinery watching it. It is listed so an
 	// operator can chase the tenant to complete checkout, which is a
 	// different action from an expiring trial's.
+	//
+	// NOTE (#827): Bootstrap no longer creates rows in `signup` — it creates
+	// `trialing`, precisely because a signup row's trial end is notional and
+	// nothing acts on it. This option therefore reaches only rows written
+	// before that change, or ones a future writer puts there.
 	IncludeSignup bool
+
+	// IncludeEnded drops the window's LOWER bound, so trials whose effective
+	// end has already passed are returned alongside those still to come.
+	//
+	// Off by default: the question this endpoint answers by default is "which
+	// trials expire this week" — a work queue, and a queue full of trials
+	// that ended months ago is not one.
+	//
+	// It exists because an ended-but-still-trialing row was invisible
+	// everywhere. A forward window cannot show one at ANY width, and that
+	// state is the most diagnostic there is: ExpiryCron selects exactly these
+	// rows, so a trial still `trialing` days after its end means the cron is
+	// not running. Two production stores sat that way and no screen could
+	// show it.
+	//
+	// Like the other two, it is unreachable from CountExpiring — the KPI
+	// counts what is ABOUT to expire, and an overdue trial is a different
+	// number that must not be folded into it.
+	IncludeEnded bool
 }
 
 // expiringScope narrows to trials that will actually EXPIRE, in the window
@@ -96,6 +120,19 @@ func expiringScope(db *gorm.DB, asOf time.Time, window time.Duration) *gorm.DB {
 // a signup row must not reach the KPI. The false branch builds the same
 // single-status predicate it always has, unchanged.
 func trialingInWindowScope(db *gorm.DB, asOf time.Time, window time.Duration, includeSignup bool) *gorm.DB {
+	return trialingScope(db, asOf, window, includeSignup, false)
+}
+
+// trialingScope is trialingInWindowScope with the lower bound made optional.
+//
+// includeEnded swaps EndsBetweenScope's (asOf, asOf+window] for
+// EndedBeforeScope's "< asOf+window": same upper bound, no floor. Both are the
+// index-preserving two-branch predicates in endsat.go, so neither loses the
+// partial index. The brackets differ only at the horizon itself, where a trial
+// ending exactly at asOf+window is included by one and not the other — an edge
+// immaterial to a list an operator reads, and not worth a third scope to
+// reconcile.
+func trialingScope(db *gorm.DB, asOf time.Time, window time.Duration, includeSignup, includeEnded bool) *gorm.DB {
 	scoped := db.Model(&subscription.StoreSubscription{})
 	if includeSignup {
 		scoped = scoped.Where("status IN ?", []subscription.SubscriptionStatus{
@@ -103,6 +140,9 @@ func trialingInWindowScope(db *gorm.DB, asOf time.Time, window time.Duration, in
 		})
 	} else {
 		scoped = scoped.Where("status = ?", subscription.StatusTrialing)
+	}
+	if includeEnded {
+		return EndedBeforeScope(scoped, asOf.Add(window))
 	}
 	return EndsBetweenScope(scoped, asOf, asOf.Add(window))
 }
@@ -120,10 +160,10 @@ func trialingInWindowScope(db *gorm.DB, asOf time.Time, window time.Duration, in
 // predicate, so the default this list serves and the scope CountExpiring
 // counts cannot drift apart.
 func listScope(db *gorm.DB, asOf time.Time, window time.Duration, opts ListOptions) *gorm.DB {
-	if !opts.IncludeSignup && !opts.IncludeStripeManaged {
+	if !opts.IncludeSignup && !opts.IncludeStripeManaged && !opts.IncludeEnded {
 		return expiringScope(db, asOf, window)
 	}
-	scoped := trialingInWindowScope(db, asOf, window, opts.IncludeSignup)
+	scoped := trialingScope(db, asOf, window, opts.IncludeSignup, opts.IncludeEnded)
 	if !opts.IncludeStripeManaged {
 		scoped = scoped.Where("stripe_subscription_id IS NULL")
 	}

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_trials.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_trials.go
@@ -151,6 +151,11 @@ func (h *BillingTrialsHandler) list(c *gin.Context) {
 	// for — see trial.ListOptions.IncludeSignup, which also explains why the
 	// trial_ends_at such a row reports is notional.
 	includeSignup := c.Query("include_signup") == "true"
+	// include_ended turns this from a work queue into a census: trials whose
+	// end has already passed come back too, reporting negative days_remaining.
+	// Off by default so the shipped question — "which trials expire this
+	// week" — is unchanged for every existing caller.
+	includeEnded := c.Query("include_ended") == "true"
 
 	ctx := c.Request.Context()
 	asOf := h.now()
@@ -158,6 +163,7 @@ func (h *BillingTrialsHandler) list(c *gin.Context) {
 	rows, total, err := h.trials.ListExpiring(ctx, h.db, asOf, window, page, limit, trial.ListOptions{
 		IncludeStripeManaged: includeStripeManaged,
 		IncludeSignup:        includeSignup,
+		IncludeEnded:         includeEnded,
 	})
 	if err != nil {
 		h.respondErr(c, err)
@@ -272,14 +278,26 @@ func toTrialRow(r trial.ExpiringRow, names map[string]string, asOf time.Time, pc
 // the same trial. The two surfaces must agree on this number, so they share
 // the exact same arithmetic: floor(hours/24), bumped to 1 only when
 // 0 < hours < 24, floored at zero.
+// daysRemaining is signed: a trial whose end has passed reports a NEGATIVE
+// number of days, and the console renders that as "ended".
+//
+// It used to clamp negatives to zero. That was harmless while the only caller
+// was a forward window — nothing overdue could reach it — and it silently
+// destroyed the answer the moment include_ended existed: a trial that ended
+// six weeks ago would have reported 0, which reads as "today" (#827).
+//
+// A defensive clamp on a value that cannot be negative is a clamp nobody
+// re-examines when the precondition changes.
 func daysRemaining(trialEndsAt, asOf time.Time) int {
 	hoursLeft := trialEndsAt.Sub(asOf).Hours()
 	days := int(hoursLeft / 24)
 	if hoursLeft > 0 && hoursLeft < 24 {
 		days = 1
 	}
-	if days < 0 {
-		days = 0
+	// Symmetrically to the < 24h case above: an end inside the last day
+	// reports -1 rather than 0, so "ended" and "today" stay distinguishable.
+	if hoursLeft < 0 && hoursLeft > -24 {
+		days = -1
 	}
 	return days
 }

--- a/services/marketplace-api/internal/handlers/platformadmin/billing_trials_test.go
+++ b/services/marketplace-api/internal/handlers/platformadmin/billing_trials_test.go
@@ -675,7 +675,14 @@ func TestBillingTrialsDaysRemainingUsesQueryInstantNotWallClock(t *testing.T) {
 // TestBillingTrialsDaysRemainingFloorsAtZero covers daysRemaining's d <= 0
 // branch: a trial ending at or before asOf must report 0, never a negative
 // number.
-func TestBillingTrialsDaysRemainingFloorsAtZero(t *testing.T) {
+// Renamed and inverted by #827. It previously asserted the floor —
+// "trial ended before asOf must floor at 0, not negative" — which was
+// harmless while a forward window meant nothing overdue could reach the
+// formatter, and became wrong the moment include_ended could.
+//
+// days_remaining is now signed. A trial that ended six weeks ago reporting 0
+// reads as "today" in every consumer, which is the opposite of the truth.
+func TestBillingTrialsDaysRemainingIsSigned(t *testing.T) {
 	asOf := billingTrialsFixtureAsOf
 	rows := []trial.ExpiringRow{
 		{TenantID: "t-1", StoreID: "s-1", TrialEndsAt: asOf, Plan: "trial", Period: "monthly", Status: "trialing"},
@@ -697,8 +704,11 @@ func TestBillingTrialsDaysRemainingFloorsAtZero(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	require.Len(t, body.Data, 2)
-	require.Equal(t, 0, body.Data[0].DaysRemaining, "trial ending exactly at asOf must report 0, not negative")
-	require.Equal(t, 0, body.Data[1].DaysRemaining, "trial ended before asOf must floor at 0, not negative")
+	// Exactly at asOf is still 0: it ends now, it has not ended.
+	require.Equal(t, 0, body.Data[0].DaysRemaining, "a trial ending exactly at asOf must report 0")
+	// Two hours past is -1, not 0. Consumers render 0 as "today" and negatives
+	// as "ended", and those are different facts.
+	require.Equal(t, -1, body.Data[1].DaysRemaining, "an ended trial must report negative days, not 0")
 }
 
 // sharedTrialsFixture implements both platformadmin.TrialLister (for the
@@ -894,4 +904,39 @@ func TestBillingTrials_IncludeSignupReachesTheLister(t *testing.T) {
 		require.False(t, trials2.gotOpts.IncludeSignup,
 			"asking for card-backed rows must not also opt into signup ones")
 	})
+}
+
+// The census the console needs: include_ended returns trials whose end has
+// already passed, which no width of forward window can reach.
+func TestBillingTrials_IncludeEndedIsOptInAndReachesOverdueTrials(t *testing.T) {
+	asOf := billingTrialsFixtureAsOf
+	rows := []trial.ExpiringRow{
+		{TenantID: "t-1", StoreID: "s-1", TrialEndsAt: asOf.AddDate(0, 0, -42), Plan: "trial", Period: "monthly", Status: "trialing"},
+	}
+
+	// Off by default — the shipped question is unchanged for existing callers.
+	plain := &stubTrialLister{rows: rows, total: 1}
+	rec := httptest.NewRecorder()
+	billingTrialsRouter(t, plain, &stubBillingDirectory{}).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/trials", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.False(t, plain.gotOpts.IncludeEnded, "include_ended defaulted on")
+
+	// On when asked for.
+	asked := &stubTrialLister{rows: rows, total: 1}
+	rec = httptest.NewRecorder()
+	billingTrialsRouter(t, asked, &stubBillingDirectory{}).ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/admin/billing/trials?include_ended=true", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, asked.gotOpts.IncludeEnded)
+
+	var body struct {
+		Data []struct {
+			DaysRemaining int `json:"days_remaining"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Data, 1)
+	require.Equal(t, -42, body.Data[0].DaysRemaining,
+		"an overdue trial must report how long ago it ended")
 }


### PR DESCRIPTION
The console's Trials tab reads "No trials expiring in the next 7 days" while four trials exist — two of them **42 and 12 days past their end date**.

Both facts are correct. `/admin/billing/trials` answers a forward window, and a forward window cannot show an overdue trial at **any** width. So the state that matters most was unreachable: a trial still `trialing` days after its end means `ExpiryCron` — which selects exactly those rows — has stopped running.

This adds the missing dimension. It does not change what any existing caller gets.

## `ListOptions.IncludeEnded`

`ListOptions` already widened two dimensions (which statuses, card-backed or not); the lower bound was fixed at `asOf`. `IncludeEnded` swaps `EndsBetweenScope`'s `(asOf, asOf+window]` for `EndedBeforeScope`'s `< asOf+window` — same upper bound, no floor, both index-preserving predicates from `endsat.go`.

Off by default, and — like the other two — **unreachable from `CountExpiring`**. The KPI counts what is about to expire; an overdue trial is a different number and must not be folded into it.

## `days_remaining` is now signed

This is the part worth reviewing carefully, because it changes a contract an existing test pinned.

It used to clamp negatives to zero, asserted by `TestBillingTrialsDaysRemainingFloorsAtZero`. That was harmless while nothing overdue could reach the formatter — and it silently destroyed the answer the moment `include_ended` could: a trial that ended six weeks ago reported `0`, which every consumer renders as **"today"**.

A defensive clamp on a value that "cannot" be negative is a clamp nobody re-examines when the precondition changes.

Now: exactly at `asOf` is still `0` (it ends now, it has not ended); within the last day is `-1`, mirroring the existing `< 24h → 1` rule; otherwise the true negative. Nothing overdue can reach the default forward window, so **no existing caller sees a different number**.

## Also corrected

`IncludeSignup`'s doc claimed "Service.Bootstrap creates every subscription that way". Not true since #847 — Bootstrap creates `trialing`, precisely because a signup row's trial end is notional and nothing acts on it. The option now reaches only rows written before that change.

## Test plan

- [x] `gofmt`, `go build`, `go vet ./...` and `-tags integration`, full marketplace-api suite green
- [x] The floor test is inverted and renamed, with the reasoning in the diff
- [x] New: `include_ended` is off by default, on when asked, and an overdue trial reports `-42` rather than `0`
- [ ] Console and platform-api changes ship separately (tesserix-home) — this PR is inert until they do, since nothing sets the flag yet
