### PR TITLE
fix(pricing): point every public CTA somewhere that resolves (#849)

### DIFF
--- a/apps/admin/app/pricing/PricingClient.tsx
+++ b/apps/admin/app/pricing/PricingClient.tsx
@@ -487,17 +487,14 @@ export function PricingClient({ currency, pricing }: PricingClientProps) {
           >
             {pricingCopy.proCtas.conversation}
           </a>
-          <a
-            href={pricingCopy.proCtas.briefHref}
-            className={[
-              'inline-block text-sm font-medium py-2.5 px-5 rounded-md transition-colors',
-              'border border-[var(--ink-900)] text-[var(--ink-900)] hover:border-[var(--moss-700)] hover:text-[var(--moss-700)]',
-              'focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--moss-700)] focus-visible:ring-offset-1',
-            ].join(' ')}
-
-          >
-            {pricingCopy.proCtas.brief}
-          </a>
+          {/* The "Download brief" button was REMOVED here (#849), not
+              disabled or relabelled. It pointed at
+              `/pricing/mark8ly-pro-brief.pdf`, and no such asset exists —
+              `apps/admin/public` contains only badges, a favicon and an icon,
+              and the URL answers 404 in production. On a public, indexed page
+              a button that 404s is worse than no button: it spends a
+              prospect's click and reads as a broken product.
+              Bring it back with the PDF, not before. */}
         </section>
       )}
 

--- a/apps/admin/lib/copy/pricing.ts
+++ b/apps/admin/lib/copy/pricing.ts
@@ -16,6 +16,45 @@ export interface PlanCopyItem {
   features: string[]
 }
 
+/**
+ * Where the marketing site lives, for the self-serve signup CTAs.
+ *
+ * Those CTAs cross a HOST boundary, which is why they cannot be relative.
+ * This page is part of `apps/admin`, served at `admin.mark8ly.com` and
+ * `{tenant}-admin.mark8ly.com`; signup lives in `apps/onboarding`, served at
+ * `mark8ly.com`. A relative `/onboarding` resolves against the admin host and
+ * 404s — which is the class of bug #849 was opened for.
+ *
+ * `||`, not `??`, and that distinction is load-bearing here. The Docker build
+ * declares `ARG REUSABLE_PUBLIC_BUILD_ARG_6=""`, so an unset CI secret arrives
+ * as the EMPTY STRING rather than as undefined. `??` only falls back on
+ * null/undefined, so it would leave `MARKETING_URL` empty and every signup CTA
+ * would render as a bare `/onboarding` — relative, on the wrong host, 404.
+ * `SignInForm.tsx` uses `??` for the same variable and has that latent bug;
+ * see #849 for the note.
+ *
+ * The fallback is the real production host rather than a localhost default,
+ * because this string ends up in a PUBLIC, indexed page: if the build arg is
+ * ever missing, a link to the live marketing site is a far better failure than
+ * a link to someone's laptop.
+ */
+const MARKETING_URL = (
+  process.env.NEXT_PUBLIC_MARKETING_URL || 'https://mark8ly.com'
+).replace(/\/+$/, '')
+
+/**
+ * The self-serve signup entry, absolute.
+ *
+ * No `?plan=` query. The previous hrefs carried `?plan=starter` and
+ * `?plan=studio`, and NOTHING reads them — `apps/onboarding` never looks at a
+ * `plan` param, and by design cannot: the trial "starts with just an email and
+ * doesn't ask for a card. You'll only be asked to choose a plan once the trial
+ * is ending" (`apps/onboarding/app/help/page.tsx`). A parameter the receiving
+ * app ignores is a URL making a promise the product does not keep, which is
+ * the same failure mode as the dead links themselves.
+ */
+const SIGNUP_HREF = `${MARKETING_URL}/onboarding`
+
 export const pricingCopy = {
   /** Page headline. Source Serif 4, large. */
   h1: 'Pricing that grows with you.',
@@ -41,9 +80,7 @@ export const pricingCopy = {
   /** Pro card CTAs. */
   proCtas: {
     conversation: 'Start a conversation',
-    brief: 'Download brief',
-    conversationHref: '/admin/settings/billing/pro-contact',
-    briefHref: '/pricing/mark8ly-pro-brief.pdf',
+    conversationHref: '/settings/billing/pro-contact',
   },
 
   /** Pro+App add-on card. */
@@ -54,7 +91,7 @@ export const pricingCopy = {
     /** The $2,000 setup fee is a separate one-off charge, not part of the monthly price above. */
     setupFeeNote: 'Plus a $2,000 one-time setup.',
     cta: 'Add to plan',
-    ctaHref: '/admin/settings/billing/pro-app-purchase',
+    ctaHref: '/settings/billing/pro-app-purchase',
   },
 
   /** Bottom disclosure footnote. Currency is interpolated at render time. */
@@ -85,7 +122,7 @@ export const pricingCopy = {
       name: 'Starter',
       tagline: 'For merchants opening their first store.',
       cta: 'Start free trial',
-      ctaHref: '/signup?plan=starter',
+      ctaHref: SIGNUP_HREF,
       features: [
         'Up to 2 storefronts',
         'Unlimited products & orders',
@@ -101,7 +138,7 @@ export const pricingCopy = {
       name: 'Studio',
       tagline: 'For stores gaining consistent monthly revenue.',
       cta: 'Start free trial',
-      ctaHref: '/signup?plan=studio',
+      ctaHref: SIGNUP_HREF,
       features: [
         'Up to 5 storefronts',
         '50 images per product',
@@ -117,7 +154,7 @@ export const pricingCopy = {
       name: 'Pro',
       tagline: 'Built for teams scaling past $10k orders a month. Start a conversation.',
       cta: 'Start a conversation',
-      ctaHref: '/admin/settings/billing/pro-contact',
+      ctaHref: '/settings/billing/pro-contact',
       features: [
         'Up to 10 storefronts',
         'Unlimited images',

--- a/apps/admin/tests/e2e/pricing.spec.ts
+++ b/apps/admin/tests/e2e/pricing.spec.ts
@@ -82,7 +82,7 @@ test.describe("public /pricing page", () => {
     await ctx.close();
   });
 
-  test("plan CTAs render the hrefs currently shipped — all three 404, see mark8ly#834", async ({
+  test("plan CTAs point somewhere that resolves", async ({
     browser,
   }) => {
     const ctx = await browser.newContext();
@@ -108,29 +108,33 @@ test.describe("public /pricing page", () => {
     // the Pro contact CTAs are `<section>`s, role=region — they cannot
     // match `role: "article"`.)
     //
-    // These assert what the page renders TODAY, which is not the same as
-    // asserting the links work. All three hrefs 404 as of this commit:
-    //   - there is no /signup route anywhere under apps/admin/app;
-    //   - "(admin)" is a Next route GROUP, so pro-contact really lives at
-    //     /settings/billing/pro-contact — the /admin prefix is not a path.
-    // That is a product bug in lib/copy/pricing.ts, reported against
-    // mark8ly#834; fix the hrefs there and update these three strings
-    // together. Until then this test's NAME says 404 so the CI log does
-    // not read as an endorsement of the URLs.
+    // These used to pin the BROKEN values on purpose, with the test name
+    // saying "all three 404" so a green CI line did not read as an
+    // endorsement. #849 fixed the hrefs, so they now pin the working ones.
+    //
+    // Starter and Studio are matched by SHAPE, not by a literal URL: their
+    // host comes from NEXT_PUBLIC_MARKETING_URL and legitimately differs
+    // between dev, UAT and production, so a pinned string would just move the
+    // breakage to whichever environment this suite did not run in. What must
+    // hold everywhere is that the link is ABSOLUTE — signup lives on the
+    // marketing host, and a relative href resolves against the admin host and
+    // 404s, which was half of this bug.
+    //
+    // Pro stays an exact match: it is an in-app path on the tenant's own
+    // admin host, and the thing that broke it was a literal prefix.
     const planCta = (plan: RegExp) =>
       page.getByRole("article", { name: plan }).getByRole("link");
 
-    await expect(planCta(/starter plan/i)).toHaveAttribute(
-      "href",
-      "/signup?plan=starter",
-    );
-    await expect(planCta(/studio plan/i)).toHaveAttribute(
-      "href",
-      "/signup?plan=studio",
-    );
+    for (const plan of [/starter plan/i, /studio plan/i]) {
+      const href = await planCta(plan).getAttribute("href");
+      expect(href, `${plan} CTA must be an absolute signup URL`).toMatch(
+        /^https?:\/\/.+\/onboarding$/,
+      );
+    }
+
     await expect(planCta(/pro plan/i)).toHaveAttribute(
       "href",
-      "/admin/settings/billing/pro-contact",
+      "/settings/billing/pro-contact",
     );
 
     await ctx.close();

--- a/apps/admin/tests/unit/lib/copy/pricing-hrefs.test.ts
+++ b/apps/admin/tests/unit/lib/copy/pricing-hrefs.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { pricingCopy } from "@/lib/copy/pricing";
+
+/**
+ * Every CTA href the public pricing page renders.
+ *
+ * Collected from the copy module rather than listed, so a CTA added later is
+ * covered without anyone remembering to add it here — the failure this guards
+ * against is precisely a link nobody checked.
+ */
+const ALL_HREFS: ReadonlyArray<{ what: string; href: string }> = [
+  { what: "proCtas.conversationHref", href: pricingCopy.proCtas.conversationHref },
+  { what: "proApp.ctaHref", href: pricingCopy.proApp.ctaHref },
+  ...pricingCopy.plans.map((p) => ({ what: `plans.${p.id}.ctaHref`, href: p.ctaHref })),
+];
+
+describe("pricing page CTA hrefs (#849)", () => {
+  // THE bug this file exists for. `(admin)` is a Next.js route GROUP:
+  // parentheses are excluded from the URL, so `/admin/settings/...` never
+  // resolved and never could. Three CTAs carried it, and the same mistaken
+  // assumption killed five e2e specs in #834.
+  it.each(ALL_HREFS)("$what does not carry the (admin) route-group prefix", ({ href }) => {
+    expect(href.startsWith("/admin/")).toBe(false);
+    expect(href).not.toContain("/(admin)");
+  });
+
+  it.each(ALL_HREFS)("$what is not empty", ({ href }) => {
+    expect(href.trim()).not.toBe("");
+  });
+
+  // Signup crosses a HOST boundary — this page is served from the admin host,
+  // signup lives in apps/onboarding on the marketing host — so a relative
+  // href would resolve against the wrong origin and 404. Asserted as a SHAPE
+  // rather than a literal URL because the host comes from
+  // NEXT_PUBLIC_MARKETING_URL and differs between dev, UAT and production;
+  // pinning one string here would just move the breakage to another
+  // environment.
+  it.each(
+    pricingCopy.plans.filter((p) => p.id === "starter" || p.id === "studio"),
+  )("$id sends a prospect to an absolute signup URL", (plan) => {
+    expect(plan.ctaHref).toMatch(/^https?:\/\//);
+    expect(plan.ctaHref.endsWith("/onboarding")).toBe(true);
+  });
+
+  // `/signup` has never existed anywhere under apps/admin/app. If it comes
+  // back, someone has reintroduced the 404 rather than pointed at onboarding.
+  it.each(ALL_HREFS)("$what does not point at the non-existent /signup", ({ href }) => {
+    expect(href).not.toContain("/signup");
+  });
+
+  // A query parameter the receiving app ignores is a URL promising something
+  // the product does not do. apps/onboarding reads no `plan` param, and by
+  // design cannot: the trial starts from an email alone and the plan is
+  // chosen later.
+  it.each(ALL_HREFS)("$what carries no ?plan= the signup flow ignores", ({ href }) => {
+    expect(href).not.toContain("plan=");
+  });
+
+  // The in-app CTAs stay relative — they are for a merchant already signed in
+  // on their own tenant subdomain, and an absolute admin host would send them
+  // to a different tenant's admin.
+  it("keeps the in-app Pro CTAs relative to the current tenant's admin host", () => {
+    expect(pricingCopy.proCtas.conversationHref).toBe("/settings/billing/pro-contact");
+    expect(pricingCopy.proApp.ctaHref).toBe("/settings/billing/pro-app-purchase");
+  });
+
+  // Removed in #849 because the asset does not exist and the URL 404s. If a
+  // `briefHref` reappears, the PDF must exist too — this fails until whoever
+  // adds it back also deletes this test, which forces the question.
+  it("does not offer a brief download while no such asset is shipped", () => {
+    expect("briefHref" in pricingCopy.proCtas).toBe(false);
+    expect("brief" in pricingCopy.proCtas).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes every dead CTA on the public `/pricing` page (#849), and adds a unit guard so the class of bug cannot come back silently.

## The issue undercounted: there are six, not four

```
:45  proCtas.conversationHref  /admin/settings/billing/pro-contact       wrong prefix
:46  proCtas.briefHref         /pricing/mark8ly-pro-brief.pdf            404 — asset does not exist
:57  proApp.ctaHref            /admin/settings/billing/pro-app-purchase  wrong prefix
:88  plans.starter.ctaHref     /signup?plan=starter                      no such route
:104 plans.studio.ctaHref      /signup?plan=studio                       no such route
:120 plans.pro.ctaHref         /admin/settings/billing/pro-contact       wrong prefix
```

The issue named four. `proCtas.conversationHref` (`:45`) and `briefHref` (`:46`) were missed — both are rendered, at `PricingClient.tsx:480` and `:491`. All six confirmed live against the deployed page.

## Signup is on a different HOST, which the issue does not mention

This is why "build the `/signup` route" would have been the wrong fix. `/pricing` is part of **`apps/admin`**, served at `admin.mark8ly.com` and `{tenant}-admin.mark8ly.com`. Self-serve signup is `/onboarding` in **`apps/onboarding`**, served at `mark8ly.com` — a different app behind a different VirtualService authority. A relative href resolves against the admin host and 404s.

So the signup CTAs are now absolute, built from `NEXT_PUBLIC_MARKETING_URL` — the mechanism `SignInForm.tsx` already uses for exactly this crossing.

**`||`, not `??`.** The Dockerfile declares `ARG REUSABLE_PUBLIC_BUILD_ARG_6=""`, so an unset CI secret arrives as the **empty string**, not undefined. `??` only falls back on null/undefined, so it would leave the host empty and every signup CTA would render as a bare relative `/onboarding` — the same 404, reintroduced. There is a test for this.

The fallback is the real production host rather than `localhost:4201`: this string lands in a public, indexed page, and if the build arg ever goes missing a link to the live marketing site is a much better failure than a link to someone's laptop.

**`?plan=` is dropped.** Nothing reads it — `apps/onboarding` never looks at a `plan` param, and by design cannot: the trial *"starts with just an email and doesn't ask for a card. You'll only be asked to choose a plan once the trial is ending"* (`apps/onboarding/app/help/page.tsx`). A parameter the receiving app ignores is a URL promising something the product does not do, which is the same failure as the dead links.

## The brief button is removed, not relabelled

`/pricing/mark8ly-pro-brief.pdf` returns 404 and no such asset exists — `apps/admin/public` holds only badges, a favicon and an icon. On a public, indexed page a button that 404s is worse than no button: it spends a prospect's click and reads as a broken product. A comment marks the spot, and a test fails if `briefHref` reappears, forcing whoever adds it back to ship the PDF too.

## The prefix fix, and one honest limitation

`(admin)` is a Next.js route **group** — parentheses are excluded from the URL — so `/admin/settings/...` never resolved. Real paths are `/settings/billing/pro-contact` and `/settings/billing/pro-app-purchase`. Same mistaken assumption that killed five e2e specs in #834.

**Not closed by this PR:** those two paths are correct for a merchant already signed in on their tenant subdomain, which is who the Pro CTAs address. A logged-out prospect on `admin.mark8ly.com/pricing` still cannot reach them — verified, the bare admin host 404s them, and a tenant subdomain 307s to login. Giving the public page a real contact destination is a product decision and a new surface, so it is noted on #849 rather than invented here.

## Why nothing caught this

`pricing.spec.ts` asserted three of the hrefs and **passed** — it checked the values matched, never that they resolved. #834 had already renamed it to say "all three 404" out loud so the green line was not read as an endorsement. It now pins the working values instead.

More importantly, that is an **e2e** spec. This PR adds `tests/unit/lib/copy/pricing-hrefs.test.ts` to the suite that actually gates CI, asserting properties rather than a snapshot:

- no CTA carries the `/admin/` route-group prefix, or contains `/(admin)`
- no CTA points at `/signup`, and none carries a `?plan=`
- Starter and Studio are absolute and end in `/onboarding` — matched by **shape**, because the host legitimately differs between dev, UAT and prod and a pinned literal would just relocate the breakage
- the in-app Pro CTAs stay relative, so they follow the tenant's own admin host
- no `briefHref` while no asset ships

The href list is **derived from the copy module**, not hand-listed, so a CTA added later is covered without anyone remembering.

## Verification

`tsc --noEmit` clean. 24 new tests pass. Mutation-tested — each guard was confirmed to actually fail:

| mutant | result |
|---|---|
| restore `/admin/` prefix | 2 failed ✅ |
| make signup href relative | 2 failed ✅ |
| swap `\|\|` back to `??` with an empty env | 2 failed ✅ |

The third is worth noting: my first attempt at it was a `sed` that silently failed on the `||`, so the mutant never applied and the suite "passed". A mutation that never applied looks exactly like one that survived — re-applied properly, it fails as it should. Restored baseline re-verified green afterwards.

`components/dashboard/MobileAppPrompt.test.tsx` and `tests/unit/api/subscription/appCredentials.test.ts` fail 10 tests, identically on clean `origin/main` with these changes stashed. Pre-existing and unrelated.
