### PR TITLE
fix(e2e): take a real address out of two public specs, and let the hygiene guard see the shape (#850)

### DIFF
--- a/apps/admin/tests/operator/admin-verify.spec.ts
+++ b/apps/admin/tests/operator/admin-verify.spec.ts
@@ -35,7 +35,16 @@ try {
 // Always use the absolute path — the relative path in flow-state.json doesn't resolve reliably
 const ADMIN_STATE = join(__dirname, ".state", "admin-state.json");
 const ORDER_ID = state.orderId ?? "";
-const CUSTOMER_EMAIL = "admtesserix@gmail.com";
+// The customer this flow verifies, from the environment (#850).
+//
+// This was a real Gmail address as a literal. Not a credential — but PII,
+// belonging to the same account whose password leaked in #844, sitting in a
+// PUBLIC repository where it can be scraped for targeting.
+//
+// Defaulted to "" rather than to an example address, matching every other
+// operator spec here: a plausible-looking default makes the spec run and
+// assert nothing, where an empty one makes it skip and say why.
+const CUSTOMER_EMAIL = process.env.CUSTOMER_EMAIL ?? "";
 
 const SCREENSHOT_DIR = "tests/operator/.state";
 
@@ -521,6 +530,7 @@ test.describe("admin verify: orders, reviews, audit, customers", () => {
 
     // Check for test customer — soft because storefront sign-in doesn't
     // create a customer profile in marketplace-api (known gap).
+    test.skip(!CUSTOMER_EMAIL, "CUSTOMER_EMAIL not set");
     const customerVisible = await page.getByText(CUSTOMER_EMAIL).isVisible({ timeout: 5_000 }).catch(() => false);
     test.info().annotations.push({
       type: "customer",
@@ -548,6 +558,7 @@ test.describe("admin verify: orders, reviews, audit, customers", () => {
     await page.waitForLoadState("networkidle").catch(() => {});
 
     // Click on the customer row — soft because customer profile may not exist
+    test.skip(!CUSTOMER_EMAIL, "CUSTOMER_EMAIL not set");
     const customerLink = page.getByText(CUSTOMER_EMAIL).first();
     const customerVisible = await customerLink.isVisible({ timeout: 5_000 }).catch(() => false);
 

--- a/apps/admin/tests/operator/storefront-journey.spec.ts
+++ b/apps/admin/tests/operator/storefront-journey.spec.ts
@@ -633,6 +633,11 @@ test.describe("storefront journey", () => {
 
   test("14. place order and verify confirmation", async ({ browser }) => {
     test.setTimeout(45_000);
+    // Skips rather than filling an empty checkout email, matching test 7.
+    // Without this the spec would run with a blank contact field and fail
+    // deep in the order flow, reporting a checkout bug that is really an
+    // unset variable.
+    test.skip(!CUSTOMER_EMAIL, "CUSTOMER_EMAIL not set");
 
     const customerStatePath = join(STATE_DIR, "customer-state.json");
     const ctx = await browser.newContext({
@@ -655,7 +660,11 @@ test.describe("storefront journey", () => {
     await page.waitForLoadState("networkidle").catch(() => {});
 
     // Fill ALL required checkout fields (contact + shipping)
-    await page.locator("#email").fill("admtesserix@gmail.com").catch(() => {});
+    // CUSTOMER_EMAIL, which this file already reads from the environment at
+    // the top. The literal that used to be here bypassed that constant
+    // entirely — the mechanism was present and simply not used, which is why
+    // #850 is a hygiene-guard gap rather than a missing-feature one.
+    await page.locator("#email").fill(CUSTOMER_EMAIL).catch(() => {});
     await page.locator("#customer-name").fill("E2E Test Customer").catch(() => {});
     await page.locator("#ship-name").fill("E2E Test Customer").catch(() => {});
     await page.locator("#ship-line1").fill("123 Test Lane").catch(() => {});

--- a/apps/onboarding/tests/unit/e2e-credential-hygiene.spec.ts
+++ b/apps/onboarding/tests/unit/e2e-credential-hygiene.spec.ts
@@ -60,6 +60,40 @@ function e2eSources(): ReadonlyArray<[string, string]> {
  */
 const CREDENTIAL_ENV = /(PASSWORD|SECRET|API_KEY|KEY_ID|TOKEN|CREDENTIAL)/;
 
+/**
+ * Identifiers whose literal value is a credential OR personal data.
+ *
+ * Wider than CREDENTIAL_ENV by one word — EMAIL — and that word is the whole
+ * point of #850. A real Gmail address sat in
+ * `apps/admin/tests/operator/admin-verify.spec.ts` as
+ * `const CUSTOMER_EMAIL = "…"`, in a PUBLIC repository, belonging to the same
+ * account whose password leaked in #844. It is not a secret, so it is not a
+ * #844-severity problem — but it is PII that can be scraped for targeting,
+ * and nothing here could see it.
+ *
+ * It was invisible for a structural reason worth naming: both assertions
+ * above match a SHAPE that mentions `process.env`. A bare `const X = "…"`
+ * mentions no environment variable at all, so neither pattern could ever fire
+ * on it, however the identifier was named.
+ */
+const SENSITIVE_IDENT = /(PASSWORD|SECRET|API_KEY|KEY_ID|TOKEN|CREDENTIAL|EMAIL)/;
+
+/**
+ * Domains reserved by RFC 2606 / RFC 6761 for documentation and testing.
+ *
+ * Broadening the guard to treat an email as sensitive necessarily catches
+ * legitimate fixtures — `user@example.com` and friends — so the reserved
+ * names are allowed rather than maintaining a per-file allowlist, which
+ * would grow one entry at a time until it allowed the next real address.
+ * These domains cannot be registered, so a value using one cannot identify
+ * a person.
+ */
+const RESERVED_EXAMPLE = /@(?:[\w-]+\.)*(?:example\.(?:com|org|net)|test|invalid|localhost)$/i;
+
+/** An email-shaped literal. Deliberately loose: the question is whether the
+ *  value looks like it could reach a real inbox, not whether it is RFC-valid. */
+const EMAIL_SHAPED = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+
 test("no e2e spec defaults a credential env var to a literal", () => {
   for (const [name, src] of e2eSources()) {
     // process.env.FOO ?? "…" / process.env.FOO || "…", across line breaks,
@@ -77,6 +111,65 @@ test("no e2e spec defaults a credential env var to a literal", () => {
           `public. Default to "" and let the spec fail on a missing value ` +
           `instead, which is what every other spec here already does.`,
       ).toBe("");
+    }
+  }
+});
+
+test("no e2e spec assigns a credential or a real email to a bare literal", () => {
+  // The #850 shape: `const CUSTOMER_EMAIL = "a.real.person@gmail.com"`.
+  //
+  // Matched on the DECLARATION rather than on `process.env`, because the
+  // defining property of this bug is that no environment variable is
+  // mentioned. `const`, `let` and `var`, single or double quoted.
+  //
+  // An empty literal passes: `?? ""` is the fix this guard asks for
+  // everywhere else, and a bare `const X = ""` is the same statement.
+  for (const [name, src] of e2eSources()) {
+    for (const m of src.matchAll(
+      /\b(?:const|let|var)\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?::\s*[^=]+)?=\s*(?:"([^"]*)"|'([^']*)')/g,
+    )) {
+      const ident = m[1] ?? "";
+      const value = m[2] ?? m[3] ?? "";
+      if (value === "") continue;
+      if (!SENSITIVE_IDENT.test(ident.toUpperCase())) continue;
+
+      // An email-shaped value on a reserved documentation domain is a
+      // fixture, not a person.
+      if (EMAIL_SHAPED.test(value) && RESERVED_EXAMPLE.test(value)) continue;
+
+      expect(
+        false,
+        `${name} assigns a literal to ${ident}. This repository is PUBLIC. ` +
+          `If it is a credential the value is committed; if it is a real ` +
+          `email address it is personal data that can be scraped for ` +
+          `targeting (#850). Read it from process.env and default to "", ` +
+          `with test.skip(!VALUE, "VALUE not set") in the blocks that need ` +
+          `it — the idiom every other operator spec here already uses. A ` +
+          `fixture address on example.com/.test/.invalid is fine.`,
+      ).toBe(true);
+    }
+  }
+});
+
+test("no e2e spec passes a real email address inline to a page interaction", () => {
+  // The SECOND occurrence in #850 was not a declaration at all — it was
+  // `.fill("a.real.person@gmail.com")` mid-test, in a file that already read
+  // CUSTOMER_EMAIL from the environment ten lines from the top. The mechanism
+  // was present and simply bypassed, so a guard that only inspects
+  // declarations would have caught one of the two and reported the class
+  // closed.
+  for (const [name, src] of e2eSources()) {
+    for (const m of src.matchAll(/(?:"([^"@\s]+@[^"\s]+)"|'([^'@\s]+@[^'\s]+)')/g)) {
+      const value = m[1] ?? m[2] ?? "";
+      if (!EMAIL_SHAPED.test(value)) continue;
+      if (RESERVED_EXAMPLE.test(value)) continue;
+      expect(
+        false,
+        `${name} contains the literal email address ${"<redacted>"}. This ` +
+          `repository is PUBLIC — a real address here is personal data ` +
+          `(#850). Use a constant read from process.env, or a fixture on a ` +
+          `reserved domain such as example.com.`,
+      ).toBe(true);
     }
   }
 });


### PR DESCRIPTION
Removes a real personal email address from two specs in this **public** repository, and extends the credential-hygiene guard so the shape it took is actually visible to it.

The address is not reproduced anywhere in this PR, for the reason the issue gives.

## Part 1 — both occurrences

```
apps/admin/tests/operator/admin-verify.spec.ts:38       const CUSTOMER_EMAIL = "<a real gmail address>"
apps/admin/tests/operator/storefront-journey.spec.ts:658  .fill("<the same address>")
```

Not a credential, so not #844-severity — but PII belonging to the **same account** whose password leaked in #844, sitting where it can be scraped for targeting.

Both now read `CUSTOMER_EMAIL` from the environment, defaulting to `""`, with `test.skip(!CUSTOMER_EMAIL, "CUSTOMER_EMAIL not set")` in the blocks that need it — the idiom every other operator spec in that directory already uses. Defaulted to empty rather than to a plausible fixture on purpose: a fixture default makes the spec *run* and assert nothing, where an empty one makes it skip and say why.

**One thing the issue did not mention, and it changes the diagnosis.** `storefront-journey.spec.ts` **already declared** `const CUSTOMER_EMAIL = process.env.CUSTOMER_EMAIL ?? ""` at line 29 — ten lines from the top of the same file. The inline `.fill()` literal bypassed the mechanism the file already had. So this was never a missing-indirection problem; it was a guard that could not see a bypass.

That test also gained a `test.skip` it was missing: without it the spec would fill a blank contact field and fail deep in the order flow, reporting a checkout bug that is really an unset variable.

## Part 2 — the durable half

The existing guard could not have caught either occurrence, for a structural reason worth naming: **both of its assertions match a shape that mentions `process.env`.** A bare `const X = "…"` mentions no environment variable at all, so no amount of adding names to `CREDENTIAL_ENV` would ever have fired on it.

Two new assertions:

1. **`no e2e spec assigns a credential or a real email to a bare literal`** — matches the *declaration* (`const`/`let`/`var`, either quote style), not `process.env`, because the defining property of this bug is that no env var appears. An empty literal passes, since `const X = ""` is the same statement as the `?? ""` fix.
2. **`no e2e spec passes a real email address inline to a page interaction`** — catches the second occurrence, which was not a declaration at all. A declaration-only guard would have caught one of the two and reported the class closed.

`EMAIL` is added via a new `SENSITIVE_IDENT` rather than by widening `CREDENTIAL_ENV`, because an email is personal data, not a secret, and the two lists answer different questions.

**Scoping, as the issue asked.** Broadening to emails necessarily catches legitimate fixtures, so RFC 2606 / RFC 6761 reserved domains are allowed — `example.com/.org/.net`, `.test`, `.invalid`, `.localhost` — rather than a per-file allowlist, which grows one entry at a time until it allows the next real address. Those domains cannot be registered, so a value using one cannot identify a person.

## Mutation-tested in both directions

Catching real values is only half of it; a guard that also rejects every fixture gets disabled within a week.

| mutant | expected | result |
|---|---|---|
| reintroduce the bare `const` (#850's original) | caught | **2 failed** — both new tests fire ✅ |
| reintroduce the inline `.fill()` literal | caught | **failed** ✅ |
| `fixture-user@example.com` | allowed | 7 passed ✅ |
| `someone@mark8ly.test` | allowed | 7 passed ✅ |

On every mutant the five pre-existing assertions stayed green, so the new ones are doing the catching rather than something incidental breaking the suite.

## Verification

`tsc --noEmit` clean. Guard suite 7/7 on the fixed tree — and the two new assertions scan **every** e2e and operator spec across admin, onboarding and storefront, so a green run also says no other real address is sitting in those trees today.
