### PR TITLE
test(admin): give the jsdom environment Web Storage, which Node 26 shadows

### DIFF
--- a/apps/admin/vitest.setup.ts
+++ b/apps/admin/vitest.setup.ts
@@ -5,3 +5,57 @@ import { cleanup } from "@testing-library/react";
 afterEach(() => {
   cleanup();
 });
+
+// Web Storage, which this environment supplies only on some Node versions.
+//
+// `window.localStorage` reads as `undefined` under Node 26 even though the
+// document has a real origin and jsdom implements Storage:
+//
+//   - Node 26 defines `globalThis.localStorage` itself, as an accessor that
+//     returns `undefined` unless the process was started with
+//     `--localstorage-file` (it warns exactly that).
+//   - vitest's jsdom environment populates globals only for keys not already
+//     present. The key IS present — as Node's always-undefined accessor — so
+//     jsdom's real Storage never lands on it.
+//
+// Measured, because the boundary is narrower than "new Node":
+//
+//   v22.19.0  absent              MobileAppPrompt passes
+//   v24.20.0  absent              MobileAppPrompt passes
+//   v26.5.0   present, undefined  MobileAppPrompt fails 8 tests
+//
+// So this is NOT what #857 is about — CI runs 22 today and is unaffected
+// either way. It is here so the suite is runnable on 26, where
+// `MobileAppPrompt.test.tsx` otherwise dies in its `afterEach` on
+// `localStorage.clear()` and takes `cleanup()` with it, leaving later tests
+// to fail with "Found multiple elements" — failures that look like duplicate
+// renders and are not.
+//
+// Ported from tesserix-home#627, which fixed the identical thing in the
+// console.
+//
+// A real Map-backed Storage rather than no-op stubs: these tests SET a value
+// and assert the component reads it back ("stays dismissed across a remount",
+// "scopes dismissal per tenant"), so stubs that dropped writes would convert
+// hard failures into quiet false passes.
+//
+// Guarded on the VALUE, not the key: `??=` and `"localStorage" in globalThis`
+// both see Node's accessor and skip, leaving the bug in place.
+if (typeof globalThis !== "undefined" && !(globalThis as { localStorage?: unknown }).localStorage) {
+  const store = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    key: (index: number) => [...store.keys()][index] ?? null,
+    removeItem: (key: string) => void store.delete(key),
+    setItem: (key: string, value: string) => void store.set(String(key), String(value)),
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    writable: true,
+    value: storage,
+  });
+}


### PR DESCRIPTION
Makes `MobileAppPrompt.test.tsx` pass on Node 26. One file, 54 added lines.

**Narrowed.** This PR previously also carried the CI Node bump and the `appCredentials` fix. #863 does both, with a more thorough diagnosis of the `File`-realm mismatch than mine, so those are dropped here rather than duplicated. What remains does not overlap #863 at all.

## The bug

```
v22.19.0  localStorage absent              MobileAppPrompt passes
v24.20.0  localStorage absent              passes
v26.5.0   present, undefined               8 tests fail
```

Node 26 defines `globalThis.localStorage` itself, as an accessor returning `undefined` unless the process was started with `--localstorage-file` — it warns exactly that. vitest's jsdom environment populates globals only for keys **not already present**, and the key IS present, so jsdom's real Storage never lands on it.

The tell is `hasOwnProperty("localStorage") === true` with a value of `undefined`: a key that exists and reads as nothing. Constructing a `JSDOM` directly gives `typeof window.localStorage === "object"`, so neither jsdom 30 nor this repo's config is at fault.

`MobileAppPrompt` persists its dismissal (`MobileAppPrompt.tsx:50,62`), and the test's `afterEach` calls `localStorage.clear()` — which throws, and takes `cleanup()` with it, so later tests inherit a mounted DOM and fail with *"Found multiple elements"*. Those secondary failures look like duplicate-render bugs and are not.

## Two details that matter if this is ever touched

- **Map-backed `Storage`, not no-op stubs.** These tests SET a value and assert the component reads it back ("stays dismissed across a remount", "scopes dismissal per tenant"). Stubs that dropped writes would convert 8 hard failures into 8 quiet false passes — strictly worse than the state being replaced.
- **Guarded on the VALUE, not the key.** `??=` and `"localStorage" in globalThis` both see Node's accessor and skip, leaving the bug in place. `!globalThis.localStorage` is what distinguishes it.

Ported from `tesserix-home#627`, which fixed the identical thing in the console.

## Scope

**Not** what #857 is about — CI runs Node 22, so it is unaffected either way, and this changes nothing there. It exists so the suite is runnable on 26. It sits beside the Pointer Capture, `scrollIntoView` and `ResizeObserver` stubs already in `vitest.setup.ts` for the same class of environment gap.

## Verification

`MobileAppPrompt.test.tsx` passes on v22.19.0, v24.20.0 and v26.5.0. Full `apps/admin` suite green.

Note: CI on this branch will fail the **npm audit gate** on advisories published today (`next` critical, `@tiptap/core`, `js-yaml`, `sharp`). That is repo-wide and unrelated — this PR touches one test-setup file and no dependency file. See the issue filed alongside this for why those cannot currently be patched.
