### PR TITLE
feat(whitelabel): wire the Play day-30 halt, and refuse to claim the day-60 pull (#702)

### DIFF
--- a/.planning/quick/260909-ap-android-publisher/PLAN.md
+++ b/.planning/quick/260909-ap-android-publisher/PLAN.md
@@ -1,0 +1,76 @@
+# Wire the Android Publisher client — for the one step that is possible (#702)
+
+## What was asked, and what the API actually allows
+
+`internal/whitelabel/googleplay` is a frozen-interface stub: `BlockDownloads` and
+`PullApp` both return `ErrNotWired`. The task was to wire it. Verified against
+Google's reference on 2026-09-09, only one of the two can be:
+
+| step | doc comment claims | reality |
+|---|---|---|
+| Day 30 `BlockDownloads` | "update the default track's rollout so no new downloads" | **Implementable.** A production-track release set to `halted` — "The release's APKs will no longer be served to users" — is exactly this, and existing installs keep working. |
+| Day 60 `PullApp` | "remove the app listing via `edits.tracks.update` flipping state to **unpublished**" | **Not implementable.** There is no `unpublished` status; the four values are `draft`, `inProgress`, `halted`, `completed`. `edits.tracks.update` manages releases within a track and cannot delist. `applications` has exactly one method, `dataSafety`. Unpublishing is a Play Console action with no API. |
+
+So the package's own doc comment describes a mechanism that does not exist. That
+is the defect class this estate keeps finding: a comment stating a reason, or here
+a mechanism, that is simply false — and it is the reason nobody noticed day 60 was
+unbuildable.
+
+**The dependency note is also stale.** The header says adding
+`google.golang.org/api/androidpublisher` "is a follow-up"; `go.mod:44` already has
+`google.golang.org/api v0.287.1` and `go.mod:40` has `golang.org/x/oauth2 v0.36.0`.
+Nothing new to add.
+
+## Scope
+
+Wire `BlockDownloads` for real. Make `PullApp` honest. Correct the comments. Do
+**not** invent a day-60 mechanism, and do not quietly redefine `PullApp` to mean
+`BlockDownloads` — a cancelled merchant's listing staying up is a fact the
+platform should state, not paper over.
+
+## Tasks
+
+### 1. Wire BlockDownloads against Android Publisher
+- [ ] Service-account OAuth2: sign a RS256 JWT from the stored service-account
+      JSON, exchange for a token, scope `androidpublisher`. `internal/whitelabel/
+      apple/client.go` is the template for shape — credentials fetched at call
+      time and never held on the Client (spec §18.9), a token TTL, and a typed
+      error for auth failure (`apple/client.go:63` distinguishes revoked keys).
+- [ ] The Publisher edit lifecycle: `edits.insert` -> `edits.tracks.get` /
+      `edits.tracks.update` setting the production release `status: "halted"` ->
+      `edits.commit`. An abandoned edit must not leak: `edits.delete` on any
+      failure path after insert.
+- [ ] Idempotent, as the interface promises: a package already halted must
+      succeed, not error.
+- **Done when** a halted production track is observable, re-running is a no-op,
+  and a revoked service account surfaces a distinguishable error rather than a
+  generic one.
+
+### 2. Make PullApp fail honestly
+- [ ] Replace `ErrNotWired` with a distinct, documented error naming the real
+      constraint: unpublishing has no Android Publisher API and requires a Play
+      Console action. Do not return success.
+- [ ] The advancer already tolerates a Play-side failure as "skip for this run"
+      (`googleplay/client.go:15`, `advancer.go:256-258`). Check what that means
+      for a row that can now NEVER complete day 60, and make sure the outcome is
+      recorded rather than retried silently forever — the same reasoning
+      `advancer.go` already applies to the Firebase stub, which records that an
+      archive did not happen rather than letting the status assert one.
+- **Done when** nothing in the system claims a Play listing was pulled, and the
+  operator-visible record says why it was not.
+
+### 3. Correct the false comments
+- [ ] The package header's `PullApp` mechanism claim, and the stale dependency
+      note.
+- [ ] State what IS possible and what is not, so the next reader does not
+      re-derive it from Google's reference.
+
+## Out of scope, and why
+
+- **The package name.** Nothing produces one; `GooglePackage` is deliberately
+  empty (`discovery.go:99`, "decision 4"). So both methods are unreachable in
+  production until that is decided — the Publisher API cannot list apps, and the
+  only discovery path is Play Developer Reporting `v1beta1 apps:search` on a
+  different scope. Wiring the client is worth doing anyway: it is needed under
+  every option, and it converts "unwired" into "waiting on one input".
+- **Firebase.** `firebase/client.go:35` is a separate unwired stub.

--- a/services/marketplace-api/cmd/marketplace-api/main.go
+++ b/services/marketplace-api/cmd/marketplace-api/main.go
@@ -2496,9 +2496,12 @@ func main() {
 	// Apple, and firebase.FakeClient.ArchiveProject returns a nil error
 	// by default, so the advancer would write downloads_blocked, pulled
 	// and firebase_archived into the append-only lifecycle table for a
-	// teardown that touched nothing (#702 T3). Play and Firebase are
-	// still stubs, but their stubs return ErrNotWired, which the advancer
-	// logs — an honest "not done" instead of a silent success.
+	// teardown that touched nothing (#702 T3). Play's day-30 halt is
+	// real; its day-60 unpublish has no Android Publisher API at all and
+	// returns a refusal. Firebase remains a stub returning ErrNotWired.
+	// Both are recorded as "NOT performed" beside the status and counted
+	// by white_label_app_lifecycle_step_skipped_total — an honest "not
+	// done" instead of a silent success.
 	//
 	// Apple and Google are wired as per-tenant FACTORIES: their
 	// credentials are per-tenant and the advancer walks a multi-tenant

--- a/services/marketplace-api/internal/whitelabel/googleplay/client.go
+++ b/services/marketplace-api/internal/whitelabel/googleplay/client.go
@@ -18,9 +18,10 @@
 //
 // An earlier version of this comment claimed day 60 worked via
 // `edits.tracks.update` "flipping state to unpublished". There is no such
-// status — TrackRelease.status is one of `draft`, `inProgress`, `halted`,
-// `completed` — and `edits.tracks.update` only manages releases within a
-// track. The `applications` resource has exactly one method, `dataSafety`.
+// status — TrackRelease.status is one of `statusUnspecified`, `draft`,
+// `inProgress`, `halted` or `completed` — and `edits.tracks.update` only
+// manages releases within a track. The `applications` resource has
+// exactly one method, `dataSafety`.
 // The false mechanism is why nobody noticed day 60 was unbuildable.
 //
 // Auth is service-account OAuth2 (RS256 JWT → token exchange) via
@@ -104,17 +105,20 @@ var ErrUnauthorized = errors.New("googleplay: Google rejected the service-accoun
 var ErrUnpublishNotSupported = errors.New(
 	"googleplay: unpublishing a Play listing has no Android Publisher API; it requires a Play Console action")
 
-// ErrNotWired is retained only so callers written against the previous
-// stub keep compiling. Nothing returns it any more: BlockDownloads is
-// implemented, and PullApp returns ErrUnpublishNotSupported, which names a
-// permanent constraint rather than pending work.
-//
-// Deprecated: match on ErrUnauthorized or ErrUnpublishNotSupported.
-var ErrNotWired = errors.New("googleplay: android publisher integration not yet wired")
-
-// Release statuses from TrackRelease.status. Only these four are valid;
-// `unpublished` does not exist (see the package doc).
+// Release statuses from TrackRelease.status. These five are the whole
+// enum; `unpublished` is not among them (see the package doc). The
+// package deliberately has no ErrNotWired: day 30 is implemented and day
+// 60 is impossible, so nothing here is pending work.
+// firebase.ErrNotWired still exists and DOES mean pending work — keeping
+// a same-named error here would make the two indistinguishable at a
+// glance, which is how the two false comments this change removes
+// survived in the first place.
 const (
+	// releaseStatusUnspecified carries no information about whether the
+	// release is being served, so BlockDownloads refuses it rather than
+	// guessing. See haltServingReleases.
+	releaseStatusUnspecified = "statusUnspecified"
+
 	releaseStatusDraft      = "draft"
 	releaseStatusInProgress = "inProgress"
 	releaseStatusHalted     = "halted"
@@ -221,6 +225,9 @@ func New(cfg Config) (*Client, error) {
 // abandoned and nil is returned. Committing an unchanged edit would be a
 // pointless write against the merchant's account, and erroring would make
 // the second tick of a retried teardown fail.
+//
+// A release whose status this code does not recognise is an ERROR, not a
+// quiet pass-through: see haltServingReleases.
 func (c *Client) BlockDownloads(ctx context.Context, packageName string) (err error) {
 	if packageName == "" {
 		return errors.New("googleplay: packageName is required")
@@ -256,7 +263,11 @@ func (c *Client) BlockDownloads(ctx context.Context, packageName string) (err er
 		return classify("edits.tracks.get("+productionTrack+")", packageName, err)
 	}
 
-	halted, changed := haltServingReleases(track)
+	halted, changed, err := haltServingReleases(track)
+	if err != nil {
+		// The deferred delete above still abandons the edit.
+		return err
+	}
 	if !changed {
 		return nil
 	}
@@ -293,21 +304,46 @@ func (c *Client) PullApp(_ context.Context, packageName string) error {
 // `halted` is already the target, so both are copied through untouched:
 // re-halting is what makes this method idempotent, and un-drafting a
 // release the merchant staged but never shipped is not day 30's business.
-func haltServingReleases(track *androidpublisher.Track) (*androidpublisher.Track, bool) {
+//
+// AN UNRECOGNISED STATUS IS AN ERROR. Copying it through would leave
+// `changed` false, which makes BlockDownloads abandon the edit and return
+// nil — and the advancer then writes `downloads_blocked` for an app that
+// may still be serving. A step reporting success it never performed is
+// the exact defect #702 exists to remove, so this refuses instead.
+// `statusUnspecified` is refused for the same reason rather than assumed
+// harmless: it says nothing about whether APKs are being served.
+func haltServingReleases(track *androidpublisher.Track) (*androidpublisher.Track, bool, error) {
 	out := &androidpublisher.Track{Track: track.Track}
 	changed := false
-	for _, rel := range track.Releases {
+	for i, rel := range track.Releases {
 		next := *rel
 		switch rel.Status {
 		case releaseStatusInProgress, releaseStatusCompleted:
 			next.Status = releaseStatusHalted
+			// countryTargeting is documented as settable only for
+			// inProgress releases in the production track, so leaving it
+			// on a now-halted release can fail the update on that field
+			// alone — which would break precisely the geo-staged rollout
+			// this branch claims to handle. Clearing it widens nothing: a
+			// halted release serves nowhere by definition.
+			next.CountryTargeting = nil
 			changed = true
 		case releaseStatusDraft, releaseStatusHalted:
 			// Already not serving.
+		case releaseStatusUnspecified:
+			return nil, false, fmt.Errorf(
+				"googleplay: production release %d (%q) reports status %q, which does not say whether "+
+					"its APKs are served; refusing to report a halt that may not have happened",
+				i, rel.Name, rel.Status)
+		default:
+			return nil, false, fmt.Errorf(
+				"googleplay: production release %d (%q) has unrecognised status %q; refusing to report "+
+					"a halt that may not have happened",
+				i, rel.Name, rel.Status)
 		}
 		out.Releases = append(out.Releases, &next)
 	}
-	return out, changed
+	return out, changed, nil
 }
 
 // service builds an authenticated Android Publisher client for one call.

--- a/services/marketplace-api/internal/whitelabel/googleplay/client.go
+++ b/services/marketplace-api/internal/whitelabel/googleplay/client.go
@@ -1,28 +1,52 @@
-// Package googleplay wraps the Google Play Android Publisher API for
-// the two teardown operations the §13.5 lifecycle needs:
+// Package googleplay wraps the Google Play Android Publisher API for the
+// §13.5 white-label app teardown sequence.
 //
-//   - Day 30: BlockDownloads — update the default track's rollout so no
-//     new downloads from the production channel (equivalent to halting
-//     distribution; existing installs keep working).
-//   - Day 60: PullApp — remove the app listing via Android Publisher's
-//     `edits.tracks.update` flipping state to unpublished.
+// ONE OF THE TWO STEPS IS POSSIBLE. Verified against Google's Android
+// Publisher v3 reference on 2026-09-09:
 //
-// The real Client uses Google service-account OAuth2 (RS256 JWT →
-// token exchange) plus the Android Publisher v3 REST API. Tests use
-// FakeClient (no network, no SDK dep). Main wires the real Client
-// behind a feature flag; until the full oauth2 + publisher plumbing
-// lands, production calls return ErrNotWired — the lifecycle advancer
-// treats this as a non-fatal "skip for this run" so day-30 can be
-// partially applied (Apple ok, Google deferred) without stalling.
+//   - Day 30: BlockDownloads — IMPLEMENTED. The production track's
+//     serving releases are set to `status: "halted"`, documented as "the
+//     release's APKs will no longer be served to users. Users who already
+//     have these APKs are unaffected." That is exactly the day-30 intent:
+//     no new installs, existing installs keep working.
 //
-// Adding the `google.golang.org/api/androidpublisher` dep + full oauth2
-// JWT exchange is a follow-up; flagging here keeps the advancer API
-// frozen so that addition is internal-only.
+//   - Day 60: PullApp — NOT IMPLEMENTABLE, and not faked. Unpublishing a
+//     Play listing has no Android Publisher API; it is a Play Console
+//     action. PullApp therefore returns ErrUnpublishNotSupported on every
+//     call. See the note on that error for the evidence, and for the
+//     mechanisms that were considered and rejected.
+//
+// An earlier version of this comment claimed day 60 worked via
+// `edits.tracks.update` "flipping state to unpublished". There is no such
+// status — TrackRelease.status is one of `draft`, `inProgress`, `halted`,
+// `completed` — and `edits.tracks.update` only manages releases within a
+// track. The `applications` resource has exactly one method, `dataSafety`.
+// The false mechanism is why nobody noticed day 60 was unbuildable.
+//
+// Auth is service-account OAuth2 (RS256 JWT → token exchange) via
+// golang.org/x/oauth2/google, scoped to androidpublisher. Credentials are
+// fetched per call and never stored on the Client (spec §18.9) so a key
+// rotated or revoked between calls is picked up without a restart. Both
+// `google.golang.org/api` and `golang.org/x/oauth2` are already direct
+// dependencies; nothing was added for this.
+//
+// Tests use FakeClient (no network, no credentials). Main wires the real
+// Client through lifecycle.NewGoogleTeardownFactory.
 package googleplay
 
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/androidpublisher/v3"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
 )
 
 // ClientAPI is what lifecycle/advancer depends on; tests use FakeClient.
@@ -31,55 +55,336 @@ type ClientAPI interface {
 	BlockDownloads(ctx context.Context, packageName string) error
 
 	// PullApp removes packageName's public listing. Idempotent.
+	//
+	// The real Client CANNOT do this — see ErrUnpublishNotSupported. The
+	// method stays on the interface because the lifecycle advancer's day-60
+	// step is shaped around it and must record a refusal rather than
+	// silently skip the step; removing it would make the gap invisible.
 	PullApp(ctx context.Context, packageName string) error
 }
 
-// ErrNotWired is returned by the real Client stub until the Android
-// Publisher integration is fleshed out. Lifecycle callers should log
-// and continue rather than fail the whole advance cycle on this.
+// ErrUnauthorized reports that Google rejected the service-account
+// credentials — a 401/403 from the API, a failed OAuth2 token exchange (a
+// deleted or disabled key, or a key without the androidpublisher scope),
+// or service-account JSON that will not parse.
+//
+// It is deliberately distinct from a transport failure, for the same
+// reason apple.ErrUnauthorized is: "the merchant's key no longer works"
+// needs an operator to re-onboard credentials, while "the request did not
+// reach Google" resolves itself on the next tick. A caller that conflates
+// them retries forever on the first and alarms on the second.
+var ErrUnauthorized = errors.New("googleplay: Google rejected the service-account credentials")
+
+// ErrUnpublishNotSupported reports that the day-60 "pull the listing"
+// step cannot be performed through any API.
+//
+// EVIDENCE (Android Publisher v3 reference, checked 2026-09-09):
+//
+//   - `applications` has exactly one method: `dataSafety`. There is no
+//     unpublish, delete, or delist.
+//   - `edits.tracks` (create/get/list/patch/update) manages releases
+//     WITHIN a track. TrackRelease.status is one of `draft`, `inProgress`,
+//     `halted`, `completed` — there is no `unpublished`.
+//   - Unpublishing an app is a Play Console action with no REST surface.
+//
+// Considered and rejected:
+//
+//   - `edits.listings.delete`/`deleteall` removes the localized store
+//     LISTING TEXT from an edit. The app stays published; committing that
+//     would break the listing's copy without delisting anything.
+//   - `releases[].countryTargeting` is documented as settable only for
+//     inProgress production releases and requires at least one country, so
+//     it cannot express "nowhere" — and it would not remove the listing.
+//   - Reusing BlockDownloads would be worse than failing: it would let the
+//     row claim `pulled` for work that is only the day-30 halt.
+//
+// A cancelled merchant's listing staying visible is a fact the platform
+// must state, not paper over. The lifecycle advancer records this reason
+// beside the status rather than letting the status assert a pull.
+var ErrUnpublishNotSupported = errors.New(
+	"googleplay: unpublishing a Play listing has no Android Publisher API; it requires a Play Console action")
+
+// ErrNotWired is retained only so callers written against the previous
+// stub keep compiling. Nothing returns it any more: BlockDownloads is
+// implemented, and PullApp returns ErrUnpublishNotSupported, which names a
+// permanent constraint rather than pending work.
+//
+// Deprecated: match on ErrUnauthorized or ErrUnpublishNotSupported.
 var ErrNotWired = errors.New("googleplay: android publisher integration not yet wired")
 
-// Credentials is the service-account JSON bundle read from appcreds
-// at call time — never stored on the Client. See spec §18.9.
+// Release statuses from TrackRelease.status. Only these four are valid;
+// `unpublished` does not exist (see the package doc).
+const (
+	releaseStatusDraft      = "draft"
+	releaseStatusInProgress = "inProgress"
+	releaseStatusHalted     = "halted"
+	releaseStatusCompleted  = "completed"
+)
+
+// productionTrack is the only track day-30 touches. Halting `internal`,
+// `alpha` or `beta` would stop tester distribution without affecting the
+// public listing, which is not what day 30 means.
+const productionTrack = "production"
+
+// Credentials is the service-account JSON bundle read from appcreds at
+// call time — never stored on the Client. See spec §18.9.
 type Credentials struct {
 	ServiceAccountJSON []byte
 }
 
-// Client is the production Android Publisher client. Constructing it
-// is allowed but every method returns ErrNotWired until the real
-// oauth2 + publisher plumbing lands. The shape is frozen now so the
-// advancer + main wiring don't change when the implementation fills in.
+// Client is the production Android Publisher client, backed by
+// credentials fetched per-call from appcreds.Service. The CredsFetcher
+// closure injects whatever lookup strategy the caller wants
+// (tenant → appcreds.Load).
 type Client struct {
-	credsFetcher func(ctx context.Context) (Credentials, error)
+	endpoint      string
+	tokenURL      string
+	http          *http.Client
+	credsFetcher  func(ctx context.Context) (Credentials, error)
+	tokenLifetime time.Duration
 }
 
 // Config groups Client construction params.
 type Config struct {
-	CredsFetcher func(ctx context.Context) (Credentials, error)
+	CredsFetcher func(ctx context.Context) (Credentials, error) // required
+
+	// HTTP is the transport for both the token exchange and the API
+	// calls. Default: http.Client{Timeout: 30s}.
+	HTTP *http.Client
+
+	// TokenLifetime is the assertion lifetime of the signed JWT. Google
+	// caps service-account assertions at 1 hour. Default: 15 minutes —
+	// short enough that a revoked key stops working promptly, long enough
+	// that one teardown never re-signs mid-flight.
+	TokenLifetime time.Duration
+
+	// Endpoint overrides the Android Publisher base URL. TEST ONLY;
+	// production leaves it empty to use googleapis.com.
+	Endpoint string
+
+	// TokenURL overrides the OAuth2 token endpoint. TEST ONLY, and
+	// meaningful only alongside Endpoint: a test server that serves the
+	// API must also serve the token exchange, or the client would sign a
+	// real assertion and post it to Google.
+	TokenURL string
 }
 
-// New constructs a Client. CredsFetcher is required.
+// New constructs a production Client. CredsFetcher is required; tests
+// should use FakeClient rather than a real Client with a stub fetcher,
+// except where the point of the test is this file's own HTTP behaviour.
 func New(cfg Config) (*Client, error) {
 	if cfg.CredsFetcher == nil {
 		return nil, errors.New("googleplay: Config.CredsFetcher is required")
 	}
-	return &Client{credsFetcher: cfg.CredsFetcher}, nil
+	h := cfg.HTTP
+	if h == nil {
+		h = &http.Client{Timeout: 30 * time.Second}
+	}
+	ttl := cfg.TokenLifetime
+	if ttl == 0 {
+		ttl = 15 * time.Minute
+	}
+	endpoint := cfg.Endpoint
+	if endpoint != "" && !strings.HasSuffix(endpoint, "/") {
+		// googleapi.ResolveRelative joins relative to the base path, so a
+		// base without a trailing slash silently drops its last segment.
+		endpoint += "/"
+	}
+	return &Client{
+		endpoint:      endpoint,
+		tokenURL:      cfg.TokenURL,
+		http:          h,
+		credsFetcher:  cfg.CredsFetcher,
+		tokenLifetime: ttl,
+	}, nil
 }
 
-// BlockDownloads is not yet wired — returns ErrNotWired. See package doc.
-func (c *Client) BlockDownloads(ctx context.Context, packageName string) error {
-	// Fetch creds to surface any appcreds-level failures early — real
-	// impl will use them to sign the oauth2 JWT.
-	if _, err := c.credsFetcher(ctx); err != nil {
+// BlockDownloads halts new installs of packageName by setting every
+// serving release on the production track to `halted`.
+//
+// The Android Publisher write model is an EDIT: insert an edit, mutate
+// inside it, commit. Nothing is visible on Play until the commit.
+//
+//	edits.insert → edits.tracks.get(production) → edits.tracks.update
+//	→ edits.commit
+//
+// Every return path after edits.insert abandons the edit with
+// edits.delete, including the success-without-changes path. A leaked edit
+// is a real side effect on the merchant's account: Play allows one open
+// edit at a time, so an abandoned one blocks the merchant's own releases
+// until it expires. A delete that itself fails is joined onto the returned
+// error rather than dropped — that leak needs an operator, and this
+// package has no logger to whisper it into.
+//
+// IDEMPOTENT, as the interface promises. If no release is in a serving
+// state — already halted, only drafts, or no releases at all — the edit is
+// abandoned and nil is returned. Committing an unchanged edit would be a
+// pointless write against the merchant's account, and erroring would make
+// the second tick of a retried teardown fail.
+func (c *Client) BlockDownloads(ctx context.Context, packageName string) (err error) {
+	if packageName == "" {
+		return errors.New("googleplay: packageName is required")
+	}
+	svc, err := c.service(ctx)
+	if err != nil {
 		return err
 	}
-	return ErrNotWired
+	edits := svc.Edits
+
+	edit, err := edits.Insert(packageName, &androidpublisher.AppEdit{}).Context(ctx).Do()
+	if err != nil {
+		return classify("edits.insert", packageName, err)
+	}
+
+	committed := false
+	defer func() {
+		if committed {
+			// The commit consumed the edit; deleting it now would 404.
+			return
+		}
+		// Detached from ctx so a cancellation between insert and here does
+		// not turn a recoverable failure into a leaked edit. The bound is
+		// c.http's own Timeout.
+		cleanupCtx := context.WithoutCancel(ctx)
+		if delErr := edits.Delete(packageName, edit.Id).Context(cleanupCtx).Do(); delErr != nil {
+			err = errors.Join(err, classify("edits.delete (abandoning edit "+edit.Id+")", packageName, delErr))
+		}
+	}()
+
+	track, err := edits.Tracks.Get(packageName, edit.Id, productionTrack).Context(ctx).Do()
+	if err != nil {
+		return classify("edits.tracks.get("+productionTrack+")", packageName, err)
+	}
+
+	halted, changed := haltServingReleases(track)
+	if !changed {
+		return nil
+	}
+
+	if _, err := edits.Tracks.Update(packageName, edit.Id, productionTrack, halted).Context(ctx).Do(); err != nil {
+		return classify("edits.tracks.update("+productionTrack+")", packageName, err)
+	}
+	if _, err := edits.Commit(packageName, edit.Id).Context(ctx).Do(); err != nil {
+		return classify("edits.commit", packageName, err)
+	}
+	committed = true
+	return nil
 }
 
-// PullApp is not yet wired — returns ErrNotWired. See package doc.
-func (c *Client) PullApp(ctx context.Context, packageName string) error {
-	if _, err := c.credsFetcher(ctx); err != nil {
-		return err
+// PullApp always fails. Unpublishing a Play listing has no Android
+// Publisher API — see ErrUnpublishNotSupported for the evidence and for
+// the alternatives that were considered.
+//
+// It deliberately does NOT fetch credentials first: there is no request to
+// authenticate, so a credential read here would add an audit entry
+// implying an attempt was made. And it deliberately does not return nil:
+// the caller's day-60 record must say the listing is still up.
+func (c *Client) PullApp(_ context.Context, packageName string) error {
+	return fmt.Errorf("%w (package %s)", ErrUnpublishNotSupported, packageName)
+}
+
+// haltServingReleases returns a COPY of track with every serving release
+// switched to `halted`, plus whether anything changed. The fetched track
+// is not mutated — the caller still needs the original to compare against,
+// and an in-place edit would make "did anything change" unanswerable.
+//
+// `inProgress` (a staged rollout) and `completed` (fully rolled out) are
+// the two states whose APKs are being served. `draft` is not served and
+// `halted` is already the target, so both are copied through untouched:
+// re-halting is what makes this method idempotent, and un-drafting a
+// release the merchant staged but never shipped is not day 30's business.
+func haltServingReleases(track *androidpublisher.Track) (*androidpublisher.Track, bool) {
+	out := &androidpublisher.Track{Track: track.Track}
+	changed := false
+	for _, rel := range track.Releases {
+		next := *rel
+		switch rel.Status {
+		case releaseStatusInProgress, releaseStatusCompleted:
+			next.Status = releaseStatusHalted
+			changed = true
+		case releaseStatusDraft, releaseStatusHalted:
+			// Already not serving.
+		}
+		out.Releases = append(out.Releases, &next)
 	}
-	return ErrNotWired
+	return out, changed
+}
+
+// service builds an authenticated Android Publisher client for one call.
+//
+// Constructed per call, not once on the Client, because the credentials
+// are: the CredsFetcher is the appcreds audit + metrics choke point, and a
+// key revoked since the last teardown must fail this call rather than keep
+// working off a cached token source.
+func (c *Client) service(ctx context.Context) (*androidpublisher.Service, error) {
+	creds, err := c.credsFetcher(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("googleplay: fetch creds: %w", err)
+	}
+	if len(creds.ServiceAccountJSON) == 0 {
+		return nil, fmt.Errorf("%w: service-account JSON is empty", ErrUnauthorized)
+	}
+
+	jwtCfg, err := google.JWTConfigFromJSON(creds.ServiceAccountJSON, androidpublisher.AndroidpublisherScope)
+	if err != nil {
+		// Unparseable or non-service-account JSON is a credential problem,
+		// not a transport one — the same operator action fixes it as a
+		// revoked key, so it carries the same sentinel.
+		return nil, fmt.Errorf("%w: parse service-account JSON: %v", ErrUnauthorized, err)
+	}
+	jwtCfg.Expires = c.tokenLifetime
+	if c.tokenURL != "" {
+		jwtCfg.TokenURL = c.tokenURL
+	}
+
+	// oauth2.HTTPClient is how x/oauth2 is told which transport to use for
+	// the token exchange; without it the exchange would bypass c.http and
+	// its timeout.
+	tokenCtx := context.WithValue(ctx, oauth2.HTTPClient, c.http)
+	authed := &http.Client{
+		Timeout: c.http.Timeout,
+		Transport: &oauth2.Transport{
+			Base:   c.http.Transport,
+			Source: oauth2.ReuseTokenSource(nil, jwtCfg.TokenSource(tokenCtx)),
+		},
+	}
+
+	opts := []option.ClientOption{option.WithHTTPClient(authed)}
+	if c.endpoint != "" {
+		opts = append(opts, option.WithEndpoint(c.endpoint))
+	}
+	svc, err := androidpublisher.NewService(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("googleplay: build android publisher service: %w", err)
+	}
+	return svc, nil
+}
+
+// classify turns an Android Publisher error into either ErrUnauthorized or
+// a plain wrapped error, so callers can tell "these credentials are dead"
+// from "this request did not get through".
+func classify(op, packageName string, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) {
+		if apiErr.Code == http.StatusUnauthorized || apiErr.Code == http.StatusForbidden {
+			return fmt.Errorf("%w: %s(%s): status %d", ErrUnauthorized, op, packageName, apiErr.Code)
+		}
+		return fmt.Errorf("googleplay: %s(%s): status %d: %w", op, packageName, apiErr.Code, err)
+	}
+
+	// The token exchange rejected the assertion. x/oauth2 surfaces that as
+	// *oauth2.RetrieveError, wrapped in *url.Error by http.Client — hence
+	// errors.As rather than a type switch. A revoked, deleted or
+	// wrong-scope key lands here, never as a googleapi.Error, because the
+	// API request is never sent.
+	var retrieveErr *oauth2.RetrieveError
+	if errors.As(err, &retrieveErr) {
+		return fmt.Errorf("%w: %s(%s): oauth2 token exchange: %v", ErrUnauthorized, op, packageName, retrieveErr)
+	}
+
+	return fmt.Errorf("googleplay: %s(%s): %w", op, packageName, err)
 }

--- a/services/marketplace-api/internal/whitelabel/googleplay/client_test.go
+++ b/services/marketplace-api/internal/whitelabel/googleplay/client_test.go
@@ -608,9 +608,13 @@ func TestPullApp_ReportsThatUnpublishingHasNoAPI(t *testing.T) {
 	}
 }
 
-// The failure is permanent, so it must not be reported as pending work —
-// a caller matching ErrNotWired would read it as "wire it later".
-func TestPullApp_IsNotReportedAsUnwiredWork(t *testing.T) {
+// The constraint is PERMANENT, and it must not read as pending work.
+// firebase.ErrNotWired one package over means the opposite — "an
+// implementation is coming" — and a reader who takes this for that waits
+// for a follow-up PR that can never be written. So the error is
+// ErrUnpublishNotSupported and its text says what stands in the way, with
+// no "not yet"/"not wired" wording anywhere in it.
+func TestPullApp_ReportsAPermanentConstraintNotPendingWork(t *testing.T) {
 	cli, err := googleplay.New(googleplay.Config{
 		CredsFetcher: func(context.Context) (googleplay.Credentials, error) {
 			return googleplay.Credentials{}, nil
@@ -619,8 +623,90 @@ func TestPullApp_IsNotReportedAsUnwiredWork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if got := cli.PullApp(context.Background(), "com.example.store"); errors.Is(got, googleplay.ErrNotWired) {
-		t.Errorf("err = %v, must not wrap ErrNotWired: the constraint is permanent, not pending", got)
+
+	got := cli.PullApp(context.Background(), "com.example.store")
+	if !errors.Is(got, googleplay.ErrUnpublishNotSupported) {
+		t.Fatalf("err = %v, want wraps ErrUnpublishNotSupported", got)
+	}
+	msg := strings.ToLower(got.Error())
+	for _, pending := range []string{"not yet", "not wired", "yet to be", "follow-up", "todo"} {
+		if strings.Contains(msg, pending) {
+			t.Errorf("err = %q contains %q, which reads as pending work", got, pending)
+		}
+	}
+}
+
+// ─── an unrecognised status must not pass for a halt ─────────────────
+
+// Copying an unknown status through would leave nothing changed, which
+// makes BlockDownloads abandon the edit and return nil — and the advancer
+// then writes downloads_blocked for an app that may still be serving.
+// That is a step reporting success it never performed.
+func TestBlockDownloads_UnrecognisedReleaseStatus_FailsInsteadOfReportingSuccess(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+	}{
+		{"a status this code has never seen", "someFutureStatus"},
+		// statusUnspecified is the enum's fifth value. It says nothing
+		// about whether APKs are served, so it cannot be assumed harmless.
+		{"statusUnspecified", "statusUnspecified"},
+		{"empty status", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ps := &playServer{releases: []map[string]any{
+				release(tc.status, map[string]any{"name": "41 (1.4.1)"}),
+			}}
+			srv := ps.start(t)
+
+			err := newClient(t, srv).BlockDownloads(context.Background(), "com.example.store")
+			if err == nil {
+				t.Fatal("BlockDownloads = nil; an unhaltable release must not report success")
+			}
+			if !strings.Contains(err.Error(), tc.status) {
+				t.Errorf("err = %v, want it to name the offending status %q", err, tc.status)
+			}
+			if len(ps.trackUpdates) != 0 {
+				t.Errorf("nothing should be written to the track; got %v", ps.trackUpdates)
+			}
+			if containsCall(ps.recorded(), "edits.commit") {
+				t.Errorf("the edit must not be committed; calls = %v", ps.recorded())
+			}
+			if !containsCall(ps.recorded(), "edits.delete") {
+				t.Errorf("the edit leaked; calls = %v", ps.recorded())
+			}
+		})
+	}
+}
+
+// A geo-staged rollout is a case the inProgress branch claims to handle.
+// countryTargeting is documented as settable only for inProgress
+// production releases, so round-tripping it onto a now-halted release can
+// fail the update on that field alone. Clearing it widens nothing — a
+// halted release serves nowhere.
+func TestBlockDownloads_ClearsCountryTargetingWhenHaltingAGeoStagedRollout(t *testing.T) {
+	ps := &playServer{releases: []map[string]any{
+		release("inProgress", map[string]any{
+			"userFraction":     0.25,
+			"countryTargeting": map[string]any{"countries": []string{"US", "CA"}},
+		}),
+	}}
+	srv := ps.start(t)
+
+	if err := newClient(t, srv).BlockDownloads(context.Background(), "com.example.store"); err != nil {
+		t.Fatalf("BlockDownloads: %v", err)
+	}
+	if len(ps.trackUpdates) != 1 {
+		t.Fatalf("track updates = %d, want 1", len(ps.trackUpdates))
+	}
+	rel := firstRelease(t, ps.trackUpdates[0])
+	if rel["status"] != "halted" {
+		t.Errorf("status = %v, want halted", rel["status"])
+	}
+	if _, present := rel["countryTargeting"]; present {
+		t.Errorf("countryTargeting survived onto a halted release: %#v", rel)
 	}
 }
 
@@ -663,6 +749,19 @@ func statusesIn(t *testing.T, body map[string]any) []string {
 // merchant's key" versus "retry next tick".
 func isUnauthorized(err error) bool {
 	return errors.Is(err, googleplay.ErrUnauthorized)
+}
+
+func firstRelease(t *testing.T, body map[string]any) map[string]any {
+	t.Helper()
+	raw, ok := body["releases"].([]any)
+	if !ok || len(raw) == 0 {
+		t.Fatalf("update body has no releases: %#v", body)
+	}
+	rel, ok := raw[0].(map[string]any)
+	if !ok {
+		t.Fatalf("release is not an object: %#v", raw[0])
+	}
+	return rel
 }
 
 func containsCall(calls []string, prefix string) bool {

--- a/services/marketplace-api/internal/whitelabel/googleplay/client_test.go
+++ b/services/marketplace-api/internal/whitelabel/googleplay/client_test.go
@@ -2,11 +2,215 @@ package googleplay_test
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/mark8ly/marketplace-api/internal/whitelabel/googleplay"
 )
+
+// ─── test fixtures ───────────────────────────────────────────────────
+
+// serviceAccountJSON builds a syntactically real service-account key with
+// a freshly generated RSA private key, so golang.org/x/oauth2/google
+// parses it and actually RS256-signs an assertion. A hand-written stub
+// with a fake key would fail at signing time and every test below would
+// pass for the wrong reason.
+func serviceAccountJSON(t *testing.T, tokenURL string) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal pkcs8: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+
+	body, err := json.Marshal(map[string]string{
+		"type":         "service_account",
+		"project_id":   "merchant-proj",
+		"private_key":  string(pemBytes),
+		"client_email": "teardown@merchant-proj.iam.gserviceaccount.com",
+		"token_uri":    tokenURL,
+	})
+	if err != nil {
+		t.Fatalf("marshal service account: %v", err)
+	}
+	return body
+}
+
+// playServer is a stand-in for Android Publisher plus Google's OAuth2
+// token endpoint. Every status field defaults to 0, meaning "succeed".
+type playServer struct {
+	mu    sync.Mutex
+	calls []string
+	// Bodies received by PUT .../tracks/{track}, in order.
+	trackUpdates []map[string]any
+
+	// releases is what GET .../tracks/production reports.
+	releases []map[string]any
+
+	// Per-step failure injection. 0 = succeed.
+	tokenStatus    int
+	insertStatus   int
+	trackGetStatus int
+	updateStatus   int
+	commitStatus   int
+	deleteStatus   int
+}
+
+func (p *playServer) record(format string, args ...any) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = append(p.calls, fmt.Sprintf(format, args...))
+}
+
+func (p *playServer) recorded() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.calls...)
+}
+
+func (p *playServer) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("POST /token", func(w http.ResponseWriter, _ *http.Request) {
+		p.record("token")
+		if p.tokenStatus != 0 {
+			// Shape of a real rejection for a revoked or deleted key.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(p.tokenStatus)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"Invalid JWT Signature."}`))
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"access_token": "test-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	})
+
+	const appPath = "/androidpublisher/v3/applications/{pkg}/edits"
+
+	mux.HandleFunc("POST "+appPath, func(w http.ResponseWriter, r *http.Request) {
+		p.record("edits.insert %s", r.PathValue("pkg"))
+		if p.insertStatus != 0 {
+			writeAPIError(w, p.insertStatus)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"id": "edit-1"})
+	})
+
+	// The commit URL's last segment is "{editId}:commit", so a wildcard
+	// captures the whole thing; the DELETE below shares the pattern and is
+	// separated by method.
+	mux.HandleFunc("POST "+appPath+"/{seg}", func(w http.ResponseWriter, r *http.Request) {
+		p.record("edits.commit %s", r.PathValue("seg"))
+		if p.commitStatus != 0 {
+			writeAPIError(w, p.commitStatus)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"id": "edit-1"})
+	})
+
+	mux.HandleFunc("DELETE "+appPath+"/{editId}", func(w http.ResponseWriter, r *http.Request) {
+		p.record("edits.delete %s", r.PathValue("editId"))
+		if p.deleteStatus != 0 {
+			writeAPIError(w, p.deleteStatus)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	mux.HandleFunc("GET "+appPath+"/{editId}/tracks/{track}", func(w http.ResponseWriter, r *http.Request) {
+		p.record("edits.tracks.get %s", r.PathValue("track"))
+		if p.trackGetStatus != 0 {
+			writeAPIError(w, p.trackGetStatus)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"track":    r.PathValue("track"),
+			"releases": p.releases,
+		})
+	})
+
+	mux.HandleFunc("PUT "+appPath+"/{editId}/tracks/{track}", func(w http.ResponseWriter, r *http.Request) {
+		p.record("edits.tracks.update %s", r.PathValue("track"))
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		p.mu.Lock()
+		p.trackUpdates = append(p.trackUpdates, body)
+		p.mu.Unlock()
+		if p.updateStatus != 0 {
+			writeAPIError(w, p.updateStatus)
+			return
+		}
+		writeJSON(w, http.StatusOK, body)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// writeAPIError mimics a Google API error envelope so the generated
+// client parses it into *googleapi.Error and the status code survives.
+func writeAPIError(w http.ResponseWriter, status int) {
+	writeJSON(w, status, map[string]any{
+		"error": map[string]any{
+			"code":    status,
+			"message": http.StatusText(status),
+			"status":  "ERROR",
+		},
+	})
+}
+
+// newClient wires a Client at srv for both the API and the token
+// exchange, so no test reaches googleapis.com.
+func newClient(t *testing.T, srv *httptest.Server) *googleplay.Client {
+	t.Helper()
+	tokenURL := srv.URL + "/token"
+	cli, err := googleplay.New(googleplay.Config{
+		Endpoint: srv.URL,
+		TokenURL: tokenURL,
+		HTTP:     srv.Client(),
+		CredsFetcher: func(context.Context) (googleplay.Credentials, error) {
+			return googleplay.Credentials{ServiceAccountJSON: serviceAccountJSON(t, tokenURL)}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return cli
+}
+
+func release(status string, extra map[string]any) map[string]any {
+	r := map[string]any{"status": status, "versionCodes": []string{"41"}}
+	for k, v := range extra {
+		r[k] = v
+	}
+	return r
+}
+
+// ─── construction ────────────────────────────────────────────────────
 
 func TestNew_RequiresCredsFetcher(t *testing.T) {
 	if _, err := googleplay.New(googleplay.Config{}); err == nil {
@@ -14,36 +218,339 @@ func TestNew_RequiresCredsFetcher(t *testing.T) {
 	}
 }
 
-func TestClient_BlockDownloads_ReturnsNotWired(t *testing.T) {
+func TestBlockDownloads_RejectsEmptyPackageName(t *testing.T) {
+	ps := &playServer{}
+	cli := newClient(t, ps.start(t))
+
+	if err := cli.BlockDownloads(context.Background(), ""); err == nil {
+		t.Fatal("BlockDownloads(\"\") = nil, want error")
+	}
+	// Rejected before anything is opened at Google — an edit inserted for
+	// an empty package name would be a leak with no way to name it.
+	if got := ps.recorded(); len(got) != 0 {
+		t.Errorf("no request should be issued for an empty package; got %v", got)
+	}
+}
+
+// ─── the edit lifecycle ──────────────────────────────────────────────
+
+func TestBlockDownloads_HaltsProductionAndCommits(t *testing.T) {
+	ps := &playServer{releases: []map[string]any{
+		release("completed", nil),
+	}}
+	srv := ps.start(t)
+
+	if err := newClient(t, srv).BlockDownloads(context.Background(), "com.example.store"); err != nil {
+		t.Fatalf("BlockDownloads: %v", err)
+	}
+
+	want := []string{
+		"token",
+		"edits.insert com.example.store",
+		"edits.tracks.get production",
+		"edits.tracks.update production",
+		"edits.commit edit-1:commit",
+	}
+	if got := ps.recorded(); !equalStrings(got, want) {
+		t.Fatalf("call sequence =\n  %v\nwant\n  %v", got, want)
+	}
+
+	// The committed edit must actually carry status: halted — the whole
+	// point of the step. Asserting only "update was called" would pass on
+	// a body that changed nothing.
+	if len(ps.trackUpdates) != 1 {
+		t.Fatalf("track updates = %d, want 1", len(ps.trackUpdates))
+	}
+	if got := statusesIn(t, ps.trackUpdates[0]); !equalStrings(got, []string{"halted"}) {
+		t.Errorf("committed release statuses = %v, want [halted]", got)
+	}
+}
+
+func TestBlockDownloads_HaltsInProgressRolloutToo(t *testing.T) {
+	ps := &playServer{releases: []map[string]any{
+		release("inProgress", map[string]any{"userFraction": 0.1}),
+	}}
+	srv := ps.start(t)
+
+	if err := newClient(t, srv).BlockDownloads(context.Background(), "com.example.store"); err != nil {
+		t.Fatalf("BlockDownloads: %v", err)
+	}
+	if len(ps.trackUpdates) != 1 {
+		t.Fatalf("track updates = %d, want 1", len(ps.trackUpdates))
+	}
+	if got := statusesIn(t, ps.trackUpdates[0]); !equalStrings(got, []string{"halted"}) {
+		t.Errorf("statuses = %v, want [halted]", got)
+	}
+}
+
+func TestBlockDownloads_LeavesDraftReleasesAlone(t *testing.T) {
+	ps := &playServer{releases: []map[string]any{
+		release("draft", nil),
+		release("completed", nil),
+	}}
+	srv := ps.start(t)
+
+	if err := newClient(t, srv).BlockDownloads(context.Background(), "com.example.store"); err != nil {
+		t.Fatalf("BlockDownloads: %v", err)
+	}
+	if len(ps.trackUpdates) != 1 {
+		t.Fatalf("track updates = %d, want 1", len(ps.trackUpdates))
+	}
+	// Draft is not served, so day 30 has no business changing it; halting
+	// it would also discard the merchant's staged-but-unshipped work.
+	if got := statusesIn(t, ps.trackUpdates[0]); !equalStrings(got, []string{"draft", "halted"}) {
+		t.Errorf("statuses = %v, want [draft halted]", got)
+	}
+}
+
+// ─── idempotency ─────────────────────────────────────────────────────
+
+func TestBlockDownloads_AlreadyHalted_SucceedsWithoutCommitting(t *testing.T) {
+	ps := &playServer{releases: []map[string]any{
+		release("halted", nil),
+	}}
+	srv := ps.start(t)
+
+	if err := newClient(t, srv).BlockDownloads(context.Background(), "com.example.store"); err != nil {
+		t.Fatalf("BlockDownloads on an already-halted package = %v, want nil", err)
+	}
+
+	want := []string{
+		"token",
+		"edits.insert com.example.store",
+		"edits.tracks.get production",
+		"edits.delete edit-1",
+	}
+	if got := ps.recorded(); !equalStrings(got, want) {
+		t.Fatalf("call sequence =\n  %v\nwant\n  %v", got, want)
+	}
+}
+
+func TestBlockDownloads_NoReleasesAtAll_SucceedsWithoutCommitting(t *testing.T) {
+	ps := &playServer{releases: nil}
+	srv := ps.start(t)
+
+	if err := newClient(t, srv).BlockDownloads(context.Background(), "com.example.store"); err != nil {
+		t.Fatalf("BlockDownloads = %v, want nil", err)
+	}
+	if got := ps.recorded(); containsCall(got, "edits.commit") {
+		t.Errorf("an empty track must not be committed; calls = %v", got)
+	}
+	if got := ps.recorded(); !containsCall(got, "edits.delete") {
+		t.Errorf("the unused edit must be abandoned; calls = %v", got)
+	}
+}
+
+// ─── the abandoned edit ──────────────────────────────────────────────
+
+// A leaked edit is a real side effect on the merchant's Play account:
+// Play permits one open edit at a time, so an abandoned one blocks the
+// merchant's own releases until it expires. Every failure path after
+// edits.insert must delete it — this table is the guard.
+func TestBlockDownloads_DeletesTheEditOnEveryFailurePathAfterInsert(t *testing.T) {
+	tests := []struct {
+		name         string
+		configure    func(*playServer)
+		failedStep   string
+		wantNoDelete bool
+	}{
+		{
+			name:       "tracks.get fails",
+			configure:  func(p *playServer) { p.trackGetStatus = http.StatusInternalServerError },
+			failedStep: "edits.tracks.get",
+		},
+		{
+			name:       "tracks.update fails",
+			configure:  func(p *playServer) { p.updateStatus = http.StatusInternalServerError },
+			failedStep: "edits.tracks.update",
+		},
+		{
+			name:       "commit fails",
+			configure:  func(p *playServer) { p.commitStatus = http.StatusInternalServerError },
+			failedStep: "edits.commit",
+		},
+		{
+			name:       "credentials rejected mid-lifecycle",
+			configure:  func(p *playServer) { p.trackGetStatus = http.StatusForbidden },
+			failedStep: "edits.tracks.get",
+		},
+		{
+			// The insert itself failing is the one case with nothing to
+			// clean up: no edit was created, so a DELETE would be a
+			// request against an id the client never received.
+			name:         "insert fails — nothing to abandon",
+			configure:    func(p *playServer) { p.insertStatus = http.StatusInternalServerError },
+			failedStep:   "edits.insert",
+			wantNoDelete: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ps := &playServer{releases: []map[string]any{release("completed", nil)}}
+			tc.configure(ps)
+			srv := ps.start(t)
+
+			err := newClient(t, srv).BlockDownloads(context.Background(), "com.example.store")
+			if err == nil {
+				t.Fatal("BlockDownloads = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tc.failedStep) {
+				t.Errorf("err = %v, want it to name %s", err, tc.failedStep)
+			}
+
+			deleted := containsCall(ps.recorded(), "edits.delete")
+			if tc.wantNoDelete && deleted {
+				t.Errorf("edits.delete was called with no edit to delete; calls = %v", ps.recorded())
+			}
+			if !tc.wantNoDelete && !deleted {
+				t.Errorf("edit leaked — no edits.delete; calls = %v", ps.recorded())
+			}
+		})
+	}
+}
+
+// A cleanup that fails must not be silent: the leak needs an operator, and
+// this package has no logger, so the delete failure rides back on the
+// returned error alongside the original cause.
+func TestBlockDownloads_FailedCleanupIsReportedAlongsideTheCause(t *testing.T) {
+	ps := &playServer{
+		releases:       []map[string]any{release("completed", nil)},
+		trackGetStatus: http.StatusInternalServerError,
+		deleteStatus:   http.StatusInternalServerError,
+	}
+	srv := ps.start(t)
+
+	err := newClient(t, srv).BlockDownloads(context.Background(), "com.example.store")
+	if err == nil {
+		t.Fatal("BlockDownloads = nil, want error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "edits.tracks.get") {
+		t.Errorf("err = %v, want the original cause", err)
+	}
+	if !strings.Contains(msg, "edits.delete") || !strings.Contains(msg, "edit-1") {
+		t.Errorf("err = %v, want the leaked edit id reported too", err)
+	}
+}
+
+// A successful commit consumes the edit, so deleting it afterwards would
+// be a spurious request against an id that no longer exists.
+func TestBlockDownloads_DoesNotDeleteACommittedEdit(t *testing.T) {
+	ps := &playServer{releases: []map[string]any{release("completed", nil)}}
+	srv := ps.start(t)
+
+	if err := newClient(t, srv).BlockDownloads(context.Background(), "com.example.store"); err != nil {
+		t.Fatalf("BlockDownloads: %v", err)
+	}
+	if containsCall(ps.recorded(), "edits.delete") {
+		t.Errorf("a committed edit must not be deleted; calls = %v", ps.recorded())
+	}
+}
+
+// ─── auth failures are distinguishable ───────────────────────────────
+
+func TestBlockDownloads_RevokedKey_IsAnAuthFailureNotATransportFailure(t *testing.T) {
+	// A deleted or disabled service-account key fails at the token
+	// exchange, before any API request is sent.
+	ps := &playServer{tokenStatus: http.StatusBadRequest}
+	srv := ps.start(t)
+
+	err := newClient(t, srv).BlockDownloads(context.Background(), "com.example.store")
+	if err == nil {
+		t.Fatal("BlockDownloads = nil, want error")
+	}
+	if !isUnauthorized(err) {
+		t.Errorf("err = %v, want wraps ErrUnauthorized", err)
+	}
+	if containsCall(ps.recorded(), "edits.insert") {
+		t.Errorf("no API request should be sent once the token exchange fails; calls = %v", ps.recorded())
+	}
+}
+
+func TestBlockDownloads_ForbiddenFromTheAPI_IsAnAuthFailure(t *testing.T) {
+	// The key signs fine but the service account is not linked to this
+	// developer account, or lacks the release-manager role.
+	ps := &playServer{insertStatus: http.StatusForbidden}
+	srv := ps.start(t)
+
+	err := newClient(t, srv).BlockDownloads(context.Background(), "com.example.store")
+	if !isUnauthorized(err) {
+		t.Errorf("err = %v, want wraps ErrUnauthorized", err)
+	}
+}
+
+func TestBlockDownloads_ServerErrorIsNotAnAuthFailure(t *testing.T) {
+	ps := &playServer{insertStatus: http.StatusServiceUnavailable}
+	srv := ps.start(t)
+
+	err := newClient(t, srv).BlockDownloads(context.Background(), "com.example.store")
+	if err == nil {
+		t.Fatal("BlockDownloads = nil, want error")
+	}
+	// A 503 resolves itself on the next tick; classifying it as a
+	// credential problem would send an operator to re-onboard a key that
+	// is perfectly good.
+	if isUnauthorized(err) {
+		t.Errorf("err = %v, must NOT wrap ErrUnauthorized", err)
+	}
+}
+
+func TestBlockDownloads_UnreachableHostIsNotAnAuthFailure(t *testing.T) {
+	ps := &playServer{}
+	srv := ps.start(t)
+	url := srv.URL
+	srv.Close() // nothing is listening now
+
 	cli, err := googleplay.New(googleplay.Config{
+		Endpoint: url,
+		TokenURL: url + "/token",
 		CredsFetcher: func(context.Context) (googleplay.Credentials, error) {
-			return googleplay.Credentials{ServiceAccountJSON: []byte(`{"type":"service_account"}`)}, nil
+			return googleplay.Credentials{ServiceAccountJSON: serviceAccountJSON(t, url+"/token")}, nil
 		},
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	err = cli.BlockDownloads(context.Background(), "com.example.app")
-	if !errors.Is(err, googleplay.ErrNotWired) {
-		t.Errorf("BlockDownloads = %v, want wraps ErrNotWired", err)
+
+	blockErr := cli.BlockDownloads(context.Background(), "com.example.store")
+	if blockErr == nil {
+		t.Fatal("BlockDownloads = nil, want error")
+	}
+	if isUnauthorized(blockErr) {
+		t.Errorf("err = %v, must NOT wrap ErrUnauthorized", blockErr)
 	}
 }
 
-func TestClient_PullApp_ReturnsNotWired(t *testing.T) {
+func TestBlockDownloads_MalformedServiceAccountJSONIsAnAuthFailure(t *testing.T) {
 	cli, err := googleplay.New(googleplay.Config{
 		CredsFetcher: func(context.Context) (googleplay.Credentials, error) {
-			return googleplay.Credentials{ServiceAccountJSON: []byte(`{"type":"service_account"}`)}, nil
+			return googleplay.Credentials{ServiceAccountJSON: []byte(`{"type":"authorized_user"}`)}, nil
 		},
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if err := cli.PullApp(context.Background(), "com.example.app"); !errors.Is(err, googleplay.ErrNotWired) {
-		t.Errorf("PullApp = %v, want wraps ErrNotWired", err)
+	if got := cli.BlockDownloads(context.Background(), "com.example.store"); !isUnauthorized(got) {
+		t.Errorf("err = %v, want wraps ErrUnauthorized", got)
 	}
 }
 
-func TestClient_CredsFetcherError_SurfacesBeforeNotWired(t *testing.T) {
+func TestBlockDownloads_EmptyServiceAccountJSONIsAnAuthFailure(t *testing.T) {
+	cli, err := googleplay.New(googleplay.Config{
+		CredsFetcher: func(context.Context) (googleplay.Credentials, error) {
+			return googleplay.Credentials{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got := cli.BlockDownloads(context.Background(), "com.example.store"); !isUnauthorized(got) {
+		t.Errorf("err = %v, want wraps ErrUnauthorized", got)
+	}
+}
+
+func TestBlockDownloads_CredsFetcherErrorSurfaces(t *testing.T) {
 	sentinel := errors.New("creds read failed")
 	cli, err := googleplay.New(googleplay.Config{
 		CredsFetcher: func(context.Context) (googleplay.Credentials, error) {
@@ -53,11 +560,71 @@ func TestClient_CredsFetcherError_SurfacesBeforeNotWired(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	err = cli.BlockDownloads(context.Background(), "com.example")
-	if !errors.Is(err, sentinel) {
-		t.Errorf("err = %v, want wraps sentinel (creds failure should surface before ErrNotWired)", err)
+	if got := cli.BlockDownloads(context.Background(), "com.example"); !errors.Is(got, sentinel) {
+		t.Errorf("err = %v, want wraps the appcreds failure", got)
 	}
 }
+
+// ─── PullApp is honest ───────────────────────────────────────────────
+
+// Unpublishing a Play listing has no Android Publisher API. PullApp must
+// say so — not succeed, and not quietly do the day-30 halt instead.
+func TestPullApp_ReportsThatUnpublishingHasNoAPI(t *testing.T) {
+	ps := &playServer{releases: []map[string]any{release("completed", nil)}}
+	srv := ps.start(t)
+
+	credsRead := 0
+	cli, err := googleplay.New(googleplay.Config{
+		Endpoint: srv.URL,
+		TokenURL: srv.URL + "/token",
+		HTTP:     srv.Client(),
+		CredsFetcher: func(context.Context) (googleplay.Credentials, error) {
+			credsRead++
+			return googleplay.Credentials{ServiceAccountJSON: serviceAccountJSON(t, srv.URL+"/token")}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	pullErr := cli.PullApp(context.Background(), "com.example.store")
+	if pullErr == nil {
+		t.Fatal("PullApp = nil; a listing that is still up must not report success")
+	}
+	if !errors.Is(pullErr, googleplay.ErrUnpublishNotSupported) {
+		t.Errorf("err = %v, want wraps ErrUnpublishNotSupported", pullErr)
+	}
+	if !strings.Contains(pullErr.Error(), "com.example.store") {
+		t.Errorf("err = %v, want it to name the package so the record is actionable", pullErr)
+	}
+
+	// No request, and no credential read: an appcreds access would put an
+	// audit entry on the merchant's key implying an attempt was made.
+	if got := ps.recorded(); len(got) != 0 {
+		t.Errorf("PullApp issued requests: %v", got)
+	}
+	if credsRead != 0 {
+		t.Errorf("credentials read %d times; want 0", credsRead)
+	}
+}
+
+// The failure is permanent, so it must not be reported as pending work —
+// a caller matching ErrNotWired would read it as "wire it later".
+func TestPullApp_IsNotReportedAsUnwiredWork(t *testing.T) {
+	cli, err := googleplay.New(googleplay.Config{
+		CredsFetcher: func(context.Context) (googleplay.Credentials, error) {
+			return googleplay.Credentials{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got := cli.PullApp(context.Background(), "com.example.store"); errors.Is(got, googleplay.ErrNotWired) {
+		t.Errorf("err = %v, must not wrap ErrNotWired: the constraint is permanent, not pending", got)
+	}
+}
+
+// ─── fake ────────────────────────────────────────────────────────────
 
 func TestFakeClient_Counts(t *testing.T) {
 	f := googleplay.NewFakeClient()
@@ -70,4 +637,51 @@ func TestFakeClient_Counts(t *testing.T) {
 	if f.PullAppCallCount != 2 {
 		t.Errorf("Pull count = %d, want 2", f.PullAppCallCount)
 	}
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────
+
+func statusesIn(t *testing.T, body map[string]any) []string {
+	t.Helper()
+	raw, ok := body["releases"].([]any)
+	if !ok {
+		t.Fatalf("update body has no releases array: %#v", body)
+	}
+	out := make([]string, 0, len(raw))
+	for _, r := range raw {
+		rel, ok := r.(map[string]any)
+		if !ok {
+			t.Fatalf("release is not an object: %#v", r)
+		}
+		status, _ := rel["status"].(string)
+		out = append(out, status)
+	}
+	return out
+}
+
+// isUnauthorized is the check a caller makes to decide "re-onboard this
+// merchant's key" versus "retry next tick".
+func isUnauthorized(err error) bool {
+	return errors.Is(err, googleplay.ErrUnauthorized)
+}
+
+func containsCall(calls []string, prefix string) bool {
+	for _, c := range calls {
+		if strings.HasPrefix(c, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/services/marketplace-api/internal/whitelabel/lifecycle/advancer.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/advancer.go
@@ -2,6 +2,7 @@ package lifecycle
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -165,10 +166,12 @@ func (a *Advancer) advanceOne(ctx context.Context, r Row, now time.Time) error {
 // ─── Per-step actions ────────────────────────────────────────────────
 
 // blockDownloads calls Apple and Google to halt new downloads.
-// Idempotent — Apple PATCH is safe to re-apply; Google PATCH too.
-// If Apple succeeds but Google fails, the row stays at
-// sunset_scheduled and re-runs next tick; Apple re-application is a
-// no-op.
+// Idempotent — Apple's PATCH is safe to re-apply, and Play's edit
+// lifecycle short-circuits when the production track is already halted.
+//
+// An Apple failure stalls the row (see appleClient); a Play failure is
+// tolerated but WRITTEN DOWN, because the row is about to claim
+// downloads_blocked and that status cannot say "Apple only".
 func (a *Advancer) blockDownloads(ctx context.Context, r Row) error {
 	if r.AppleAppID != "" {
 		cli, err := a.appleClient(ctx, r)
@@ -182,21 +185,26 @@ func (a *Advancer) blockDownloads(ctx context.Context, r Row) error {
 	if r.GooglePackage != "" {
 		cli, err := a.googleClient(ctx, r)
 		if err != nil {
-			a.logger.WarnContext(ctx, "lifecycle: google client unavailable; block downloads skipped",
-				"store_id", r.StoreID, "err", err)
+			a.recordGoogleSkip(ctx, r, StatusDownloadsBlocked, "block downloads", err)
 			return nil
 		}
 		if err := cli.BlockDownloads(ctx, r.GooglePackage); err != nil {
-			// Google's ErrNotWired is tolerated — it means Apple was
-			// successful and Google integration is deferred. Logged
-			// and swallowed rather than stalling the advance.
-			a.logger.WarnContext(ctx, "lifecycle: google block downloads skipped",
-				"store_id", r.StoreID, "err", err)
+			a.recordGoogleSkip(ctx, r, StatusDownloadsBlocked, "block downloads", err)
 		}
 	}
 	return nil
 }
 
+// pullApps removes the public listings at day 60.
+//
+// PLAY CANNOT DO THIS, EVER. Unpublishing a Play listing has no Android
+// Publisher API (googleplay.ErrUnpublishNotSupported), so unlike day 30
+// this is not a failure a later tick can turn into a success. The row
+// still advances — stalling would block the day-90 credential purge on
+// work no retry can complete — so the refusal is recorded beside the
+// status, exactly as archiveFirebase does for the Firebase stub. Without
+// that note the `pulled` status would be the only durable record of the
+// step, asserting a takedown that did not happen.
 func (a *Advancer) pullApps(ctx context.Context, r Row) error {
 	if r.AppleAppID != "" {
 		cli, err := a.appleClient(ctx, r)
@@ -210,16 +218,45 @@ func (a *Advancer) pullApps(ctx context.Context, r Row) error {
 	if r.GooglePackage != "" {
 		cli, err := a.googleClient(ctx, r)
 		if err != nil {
-			a.logger.WarnContext(ctx, "lifecycle: google client unavailable; pull app skipped",
-				"store_id", r.StoreID, "err", err)
+			a.recordGoogleSkip(ctx, r, StatusPulled, "pull app", err)
 			return nil
 		}
 		if err := cli.PullApp(ctx, r.GooglePackage); err != nil {
-			a.logger.WarnContext(ctx, "lifecycle: google pull app skipped",
-				"store_id", r.StoreID, "err", err)
+			a.recordGoogleSkip(ctx, r, StatusPulled, "pull app", err)
 		}
 	}
 	return nil
+}
+
+// recordGoogleSkip writes down Play work the advancer did not do, next to
+// the status that is about to imply it did.
+//
+// The status cannot carry the caveat: it is a fixed value the state
+// machine reads to reach the next step, and erroring instead would stall
+// the row — permanently, in the day-60 case, since no retry can unpublish
+// a listing. So the truth goes BESIDE the status, in the same append-only
+// lifecycle table a reader already consults. This is the reasoning
+// archiveFirebase applies to the Firebase stub; tesserix-home#702's whole
+// subject is a system reporting work it did not do.
+//
+// The note write is deliberately non-fatal: failing the advance on a
+// bookkeeping insert would stall the row, and the WARN has already gone
+// out.
+func (a *Advancer) recordGoogleSkip(ctx context.Context, r Row, next Status, step string, cause error) {
+	a.logger.WarnContext(ctx, "lifecycle: google "+step+" skipped",
+		"store_id", r.StoreID, "package", r.GooglePackage, "err", cause)
+
+	reason := fmt.Sprintf("google play %s NOT performed for package %s: %v", step, r.GooglePackage, cause)
+	if errors.Is(cause, googleplay.ErrUnpublishNotSupported) {
+		// Say what an operator has to DO. A reason that only reports the
+		// API gap reads as a bug to be fixed in code, and this one cannot
+		// be: the listing stays public until a human unpublishes it.
+		reason += " (still public; requires a manual Play Console unpublish)"
+	}
+	if noteErr := a.appendNote(ctx, r, next, reason); noteErr != nil {
+		a.logger.WarnContext(ctx, "lifecycle: could not record google skip",
+			"store_id", r.StoreID, "err", noteErr)
+	}
 }
 
 // appleClient resolves the App Store Connect client for one row's tenant.
@@ -254,9 +291,10 @@ func (a *Advancer) appleClient(ctx context.Context, r Row) (AppleTeardownClient,
 // googleClient resolves the Play client for one row's tenant.
 //
 // Unlike appleClient, a failure here is tolerated by the callers: Play
-// teardown is deferred (the client is a stub returning ErrNotWired) and
-// rows carry no GooglePackage by design (#702 decision 4), so this path is
-// unreached today. The asymmetry is deliberate — Apple stalls, Play warns.
+// teardown is only partly possible — day 30 works, day 60 has no API at
+// all — and rows carry no GooglePackage by design (#702 decision 4), so
+// this path is unreached today. The asymmetry is deliberate: Apple stalls,
+// Play warns AND records what it did not do (recordGoogleSkip).
 func (a *Advancer) googleClient(ctx context.Context, r Row) (googleplay.ClientAPI, error) {
 	if a.google == nil {
 		return nil, fmt.Errorf("lifecycle: no Google client factory configured (store %s carries package %s)",

--- a/services/marketplace-api/internal/whitelabel/lifecycle/advancer.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/advancer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -185,15 +186,25 @@ func (a *Advancer) blockDownloads(ctx context.Context, r Row) error {
 	if r.GooglePackage != "" {
 		cli, err := a.googleClient(ctx, r)
 		if err != nil {
-			a.recordGoogleSkip(ctx, r, StatusDownloadsBlocked, "block downloads", err)
+			a.recordGoogleSkip(ctx, r, StatusDownloadsBlocked, stepBlockDownloads, err)
 			return nil
 		}
 		if err := cli.BlockDownloads(ctx, r.GooglePackage); err != nil {
-			a.recordGoogleSkip(ctx, r, StatusDownloadsBlocked, "block downloads", err)
+			a.recordGoogleSkip(ctx, r, StatusDownloadsBlocked, stepBlockDownloads, err)
 		}
 	}
 	return nil
 }
+
+// Teardown step identifiers. They are Prometheus label values as well as
+// note wording (recordGoogleSkip renders underscores as spaces), so they
+// must stay a small closed set — see wlmetrics.LifecycleStepSkipped.
+const (
+	stepBlockDownloads      = "block_downloads"
+	stepBlockDownloadsRetry = "block_downloads_day60_retry"
+	stepPullApp             = "pull_app"
+	stepArchiveProject      = "archive_project"
+)
 
 // pullApps removes the public listings at day 60.
 //
@@ -205,6 +216,9 @@ func (a *Advancer) blockDownloads(ctx context.Context, r Row) error {
 // status, exactly as archiveFirebase does for the Firebase stub. Without
 // that note the `pulled` status would be the only durable record of the
 // step, asserting a takedown that did not happen.
+//
+// The day-30 halt IS retryable, and is re-attempted here before the pull.
+// See the comment on that call.
 func (a *Advancer) pullApps(ctx context.Context, r Row) error {
 	if r.AppleAppID != "" {
 		cli, err := a.appleClient(ctx, r)
@@ -218,11 +232,25 @@ func (a *Advancer) pullApps(ctx context.Context, r Row) error {
 	if r.GooglePackage != "" {
 		cli, err := a.googleClient(ctx, r)
 		if err != nil {
-			a.recordGoogleSkip(ctx, r, StatusPulled, "pull app", err)
+			a.recordGoogleSkip(ctx, r, StatusPulled, stepPullApp, err)
 			return nil
 		}
+		// RE-ATTEMPT THE DAY-30 HALT FIRST. Day 30 advances the row
+		// whether or not Play was reached, so a transient failure there —
+		// a 503, a momentarily unreachable Google — would otherwise leave
+		// the app serving forever with no second chance. BlockDownloads
+		// is idempotent (an already-halted production track short-circuits
+		// without committing an edit), so this costs one GET when day 30
+		// succeeded, and converts "permanently unhalted" into "halted one
+		// tick late" when it did not.
+		//
+		// It is deliberately not a substitute for the pull below: halting
+		// stops new installs, it does not remove the listing.
+		if err := cli.BlockDownloads(ctx, r.GooglePackage); err != nil {
+			a.recordGoogleSkip(ctx, r, StatusPulled, stepBlockDownloadsRetry, err)
+		}
 		if err := cli.PullApp(ctx, r.GooglePackage); err != nil {
-			a.recordGoogleSkip(ctx, r, StatusPulled, "pull app", err)
+			a.recordGoogleSkip(ctx, r, StatusPulled, stepPullApp, err)
 		}
 	}
 	return nil
@@ -243,10 +271,16 @@ func (a *Advancer) pullApps(ctx context.Context, r Row) error {
 // bookkeeping insert would stall the row, and the WARN has already gone
 // out.
 func (a *Advancer) recordGoogleSkip(ctx context.Context, r Row, next Status, step string, cause error) {
-	a.logger.WarnContext(ctx, "lifecycle: google "+step+" skipped",
-		"store_id", r.StoreID, "package", r.GooglePackage, "err", cause)
+	// The counter is the only thing an alert can see. LifecycleTransition
+	// increments identically whether or not Play was reached, and a reason
+	// string inside a database row is not a signal.
+	wlmetrics.LifecycleStepSkipped.WithLabelValues("google_play", step).Inc()
 
-	reason := fmt.Sprintf("google play %s NOT performed for package %s: %v", step, r.GooglePackage, cause)
+	a.logger.WarnContext(ctx, "lifecycle: google step skipped",
+		"store_id", r.StoreID, "package", r.GooglePackage, "step", step, "err", cause)
+
+	reason := fmt.Sprintf("google play %s NOT performed for package %s: %v",
+		strings.ReplaceAll(step, "_", " "), r.GooglePackage, cause)
 	if errors.Is(cause, googleplay.ErrUnpublishNotSupported) {
 		// Say what an operator has to DO. A reason that only reports the
 		// API gap reads as a bug to be fixed in code, and this one cannot
@@ -327,6 +361,7 @@ func (a *Advancer) archiveFirebase(ctx context.Context, r Row) error {
 		// it. tesserix-home#702's whole subject is a system reporting work
 		// it did not do; a status this code KNOWS is untrue must not be
 		// left as the only thing written down.
+		wlmetrics.LifecycleStepSkipped.WithLabelValues("firebase", stepArchiveProject).Inc()
 		if noteErr := a.appendNote(ctx, r, StatusFirebaseArchived,
 			fmt.Sprintf("firebase archive NOT performed for project %s: %v", r.FirebaseProjectID, err),
 		); noteErr != nil {

--- a/services/marketplace-api/internal/whitelabel/lifecycle/advancer_integration_test.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/advancer_integration_test.go
@@ -6,10 +6,12 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
@@ -20,6 +22,7 @@ import (
 	"github.com/mark8ly/marketplace-api/internal/whitelabel/firebase"
 	"github.com/mark8ly/marketplace-api/internal/whitelabel/googleplay"
 	"github.com/mark8ly/marketplace-api/internal/whitelabel/lifecycle"
+	wlmetrics "github.com/mark8ly/marketplace-api/internal/whitelabel/metrics"
 	"github.com/mark8ly/marketplace-api/pkg/testdb"
 )
 
@@ -431,6 +434,7 @@ func TestAdvancer_Day60_PlayUnpublishRefusal_IsRecordedBesideTheStatus(t *testin
 	db := testdb.NewDB(t, "white_label_app_state", "white_label_app_lifecycle")
 	row := ageRow(t, 60, lifecycle.StatusDownloadsBlocked)
 	require.NoError(t, db.Create(&row).Error)
+	before := skippedNow(t, "google_play", "pull_app")
 
 	require.NoError(t, adv.AdvanceDue(context.Background()))
 
@@ -439,17 +443,78 @@ func TestAdvancer_Day60_PlayUnpublishRefusal_IsRecordedBesideTheStatus(t *testin
 	require.Equal(t, lifecycle.StatusPulled, after.Status)
 	require.Equal(t, 1, appleCli.PullAppCallCount, "Apple's pull is what makes the step partly real")
 
-	var reasons []string
-	require.NoError(t, db.Raw(
-		`SELECT reason FROM white_label_app_lifecycle
-		  WHERE store_id = ? AND reason IS NOT NULL`, row.StoreID,
-	).Scan(&reasons).Error)
-	require.NotEmpty(t, reasons, "a Play listing that was not pulled must leave a reason behind")
-	require.Contains(t, reasons[0], "NOT performed")
-	require.Contains(t, reasons[0], row.GooglePackage,
+	pull := findReason(t, db, row.StoreID, "pull app")
+	require.Contains(t, pull, "NOT performed")
+	require.Contains(t, pull, row.GooglePackage,
 		"the reason must name the package, or an operator cannot act on it")
-	require.Contains(t, reasons[0], "Play Console",
+	require.Contains(t, pull, "Play Console",
 		"the reason must name the manual action, since no code can do it")
+
+	require.Equal(t, 1.0, skippedDelta(t, "google_play", "pull_app", before),
+		"a recorded skip must also be counted, or nothing can alert on Play teardown failing")
+}
+
+// Day 30 advances the row whether or not Play was reached, so a transient
+// failure there gets no second chance unless day 60 re-attempts the halt.
+// BlockDownloads is idempotent, so the retry is free when day 30 worked
+// and is the only thing standing between a 503 and an app that keeps
+// serving forever.
+func TestAdvancer_Day60_RetriesTheDay30HaltBeforePulling(t *testing.T) {
+	creds, _ := newCredsSvc(t)
+	appleCli, gpCli, fbCli := apple.NewFakeClient(), googleplay.NewFakeClient(), firebase.NewFakeClient()
+	gpCli.PullAppErr = googleplay.ErrUnpublishNotSupported
+	adv := newAdvancer(t, struct {
+		Apple    *apple.FakeClient
+		Google   *googleplay.FakeClient
+		Firebase *firebase.FakeClient
+		Creds    *appcreds.Service
+	}{appleCli, gpCli, fbCli, creds})
+
+	db := testdb.NewDB(t, "white_label_app_state", "white_label_app_lifecycle")
+	row := ageRow(t, 60, lifecycle.StatusDownloadsBlocked)
+	require.NoError(t, db.Create(&row).Error)
+
+	require.NoError(t, adv.AdvanceDue(context.Background()))
+
+	require.Equal(t, 1, gpCli.BlockDownloadsCallCount,
+		"day 60 must re-attempt the halt; without it a failed day-30 halt is permanent")
+	require.Equal(t, []string{row.GooglePackage}, gpCli.BlockedPackages)
+	require.Equal(t, 1, gpCli.PullAppCallCount,
+		"the retry must not replace the pull attempt")
+}
+
+// A failed day-60 halt retry is a distinct, separately-labelled skip: it
+// is retryable, unlike the pull, so filing both under one step would leave
+// an operator unable to tell which needs attention.
+func TestAdvancer_Day60_FailedHaltRetryIsRecordedSeparatelyFromThePull(t *testing.T) {
+	creds, _ := newCredsSvc(t)
+	appleCli, gpCli, fbCli := apple.NewFakeClient(), googleplay.NewFakeClient(), firebase.NewFakeClient()
+	gpCli.BlockDownloadsErr = googleplay.ErrUnauthorized
+	gpCli.PullAppErr = googleplay.ErrUnpublishNotSupported
+	adv := newAdvancer(t, struct {
+		Apple    *apple.FakeClient
+		Google   *googleplay.FakeClient
+		Firebase *firebase.FakeClient
+		Creds    *appcreds.Service
+	}{appleCli, gpCli, fbCli, creds})
+
+	db := testdb.NewDB(t, "white_label_app_state", "white_label_app_lifecycle")
+	row := ageRow(t, 60, lifecycle.StatusDownloadsBlocked)
+	require.NoError(t, db.Create(&row).Error)
+	before := skippedNow(t, "google_play", "block_downloads_day60_retry")
+
+	require.NoError(t, adv.AdvanceDue(context.Background()))
+
+	retry := findReason(t, db, row.StoreID, "block downloads day60 retry")
+	require.Contains(t, retry, "NOT performed")
+	require.Contains(t, retry, row.GooglePackage)
+	// The Console advice belongs only on the pull: telling an operator to
+	// unpublish by hand would be wrong for a transient auth failure.
+	require.NotContains(t, retry, "Play Console")
+	require.Equal(t, 1.0, skippedDelta(t, "google_play", "block_downloads_day60_retry", before))
+
+	// And the pull's own note is still there, under its own step.
+	require.Contains(t, findReason(t, db, row.StoreID, "pull app"), "Play Console")
 }
 
 // Day 30's Play halt is implementable, so a failure here is transient —
@@ -470,6 +535,7 @@ func TestAdvancer_Day30_PlayBlockFailure_IsRecordedBesideTheStatus(t *testing.T)
 	db := testdb.NewDB(t, "white_label_app_state", "white_label_app_lifecycle")
 	row := ageRow(t, 30, lifecycle.StatusSunsetScheduled)
 	require.NoError(t, db.Create(&row).Error)
+	before := skippedNow(t, "google_play", "block_downloads")
 
 	require.NoError(t, adv.AdvanceDue(context.Background()))
 
@@ -477,16 +543,49 @@ func TestAdvancer_Day30_PlayBlockFailure_IsRecordedBesideTheStatus(t *testing.T)
 	require.NoError(t, db.Where("id=?", row.ID).First(&after).Error)
 	require.Equal(t, lifecycle.StatusDownloadsBlocked, after.Status)
 
-	var reasons []string
-	require.NoError(t, db.Raw(
-		`SELECT reason FROM white_label_app_lifecycle
-		  WHERE store_id = ? AND reason IS NOT NULL`, row.StoreID,
-	).Scan(&reasons).Error)
-	require.NotEmpty(t, reasons, "a Play halt that did not happen must leave a reason behind")
-	require.Contains(t, reasons[0], "block downloads")
-	require.Contains(t, reasons[0], row.GooglePackage)
+	note := findReason(t, db, row.StoreID, "block downloads")
+	require.Contains(t, note, "NOT performed")
+	require.Contains(t, note, row.GooglePackage)
 	// The day-60-only wording must NOT leak onto a day-30 note: telling an
 	// operator to unpublish in the Console would be wrong advice for a
 	// transient auth failure.
-	require.NotContains(t, reasons[0], "Play Console")
+	require.NotContains(t, note, "Play Console")
+	require.Equal(t, 1.0, skippedDelta(t, "google_play", "block_downloads", before))
+}
+
+// ─── note + counter helpers ──────────────────────────────────────────
+
+// findReason returns the one lifecycle note for storeID mentioning step.
+// Selecting by step rather than by row order matters now that a single
+// advance can record more than one skip.
+func findReason(t *testing.T, db *gorm.DB, storeID uuid.UUID, step string) string {
+	t.Helper()
+	var reasons []string
+	require.NoError(t, db.Raw(
+		`SELECT reason FROM white_label_app_lifecycle
+		  WHERE store_id = ? AND reason IS NOT NULL`, storeID,
+	).Scan(&reasons).Error)
+
+	var matched []string
+	for _, r := range reasons {
+		if strings.Contains(r, step) {
+			matched = append(matched, r)
+		}
+	}
+	require.Len(t, matched, 1,
+		"want exactly one note mentioning %q; all notes for this store: %v", step, reasons)
+	return matched[0]
+}
+
+// skippedNow / skippedDelta read the shared LifecycleStepSkipped counter.
+// It is process-global, so tests must assert a DELTA — an absolute value
+// depends on which tests ran before this one.
+func skippedNow(t *testing.T, surface, step string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(wlmetrics.LifecycleStepSkipped.WithLabelValues(surface, step))
+}
+
+func skippedDelta(t *testing.T, surface, step string, before float64) float64 {
+	t.Helper()
+	return skippedNow(t, surface, step) - before
 }

--- a/services/marketplace-api/internal/whitelabel/lifecycle/advancer_integration_test.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/advancer_integration_test.go
@@ -143,8 +143,8 @@ func TestAdvancer_Day30_BlocksDownloads(t *testing.T) {
 	require.NoError(t, db.Where("id=?", row.ID).First(&after).Error)
 	require.Equal(t, lifecycle.StatusDownloadsBlocked, after.Status)
 	require.Equal(t, 1, appleCli.BlockDownloadsCallCount)
-	// Google returns ErrNotWired but the advancer swallows it; the
-	// fake records the attempt.
+	// Play's day-30 halt IS implemented, so the fake's silent success is
+	// the right stand-in here; the failure paths are the two tests below.
 	require.Equal(t, 1, gpCli.BlockDownloadsCallCount)
 
 	// Transition log row appended.
@@ -409,4 +409,84 @@ func TestAdvancer_FirebaseArchiveFailure_IsRecordedBesideTheStatus(t *testing.T)
 	require.NotEmpty(t, reasons, "a skipped firebase archive must leave a reason behind")
 	require.Contains(t, reasons[0], "NOT performed")
 	require.Contains(t, reasons[0], "merchant-proj-1")
+}
+
+// Day 60 cannot be completed on Play by any code, now or later:
+// unpublishing a listing has no Android Publisher API. The row still walks
+// to `pulled` — stalling would block the day-90 credential purge on work
+// no retry can finish — so the append-only log has to carry the refusal,
+// or `pulled` becomes the only durable record and asserts a takedown that
+// never happened.
+func TestAdvancer_Day60_PlayUnpublishRefusal_IsRecordedBesideTheStatus(t *testing.T) {
+	creds, _ := newCredsSvc(t)
+	appleCli, gpCli, fbCli := apple.NewFakeClient(), googleplay.NewFakeClient(), firebase.NewFakeClient()
+	gpCli.PullAppErr = googleplay.ErrUnpublishNotSupported
+	adv := newAdvancer(t, struct {
+		Apple    *apple.FakeClient
+		Google   *googleplay.FakeClient
+		Firebase *firebase.FakeClient
+		Creds    *appcreds.Service
+	}{appleCli, gpCli, fbCli, creds})
+
+	db := testdb.NewDB(t, "white_label_app_state", "white_label_app_lifecycle")
+	row := ageRow(t, 60, lifecycle.StatusDownloadsBlocked)
+	require.NoError(t, db.Create(&row).Error)
+
+	require.NoError(t, adv.AdvanceDue(context.Background()))
+
+	var after lifecycle.Row
+	require.NoError(t, db.Where("id=?", row.ID).First(&after).Error)
+	require.Equal(t, lifecycle.StatusPulled, after.Status)
+	require.Equal(t, 1, appleCli.PullAppCallCount, "Apple's pull is what makes the step partly real")
+
+	var reasons []string
+	require.NoError(t, db.Raw(
+		`SELECT reason FROM white_label_app_lifecycle
+		  WHERE store_id = ? AND reason IS NOT NULL`, row.StoreID,
+	).Scan(&reasons).Error)
+	require.NotEmpty(t, reasons, "a Play listing that was not pulled must leave a reason behind")
+	require.Contains(t, reasons[0], "NOT performed")
+	require.Contains(t, reasons[0], row.GooglePackage,
+		"the reason must name the package, or an operator cannot act on it")
+	require.Contains(t, reasons[0], "Play Console",
+		"the reason must name the manual action, since no code can do it")
+}
+
+// Day 30's Play halt is implementable, so a failure here is transient —
+// but the row advances to `downloads_blocked` regardless (pinned by
+// TestAdvancer_Day30_GoogleClientUnresolvable_StillAdvances), and that
+// status cannot say "Apple only". The note is what keeps it honest.
+func TestAdvancer_Day30_PlayBlockFailure_IsRecordedBesideTheStatus(t *testing.T) {
+	creds, _ := newCredsSvc(t)
+	appleCli, gpCli, fbCli := apple.NewFakeClient(), googleplay.NewFakeClient(), firebase.NewFakeClient()
+	gpCli.BlockDownloadsErr = googleplay.ErrUnauthorized
+	adv := newAdvancer(t, struct {
+		Apple    *apple.FakeClient
+		Google   *googleplay.FakeClient
+		Firebase *firebase.FakeClient
+		Creds    *appcreds.Service
+	}{appleCli, gpCli, fbCli, creds})
+
+	db := testdb.NewDB(t, "white_label_app_state", "white_label_app_lifecycle")
+	row := ageRow(t, 30, lifecycle.StatusSunsetScheduled)
+	require.NoError(t, db.Create(&row).Error)
+
+	require.NoError(t, adv.AdvanceDue(context.Background()))
+
+	var after lifecycle.Row
+	require.NoError(t, db.Where("id=?", row.ID).First(&after).Error)
+	require.Equal(t, lifecycle.StatusDownloadsBlocked, after.Status)
+
+	var reasons []string
+	require.NoError(t, db.Raw(
+		`SELECT reason FROM white_label_app_lifecycle
+		  WHERE store_id = ? AND reason IS NOT NULL`, row.StoreID,
+	).Scan(&reasons).Error)
+	require.NotEmpty(t, reasons, "a Play halt that did not happen must leave a reason behind")
+	require.Contains(t, reasons[0], "block downloads")
+	require.Contains(t, reasons[0], row.GooglePackage)
+	// The day-60-only wording must NOT leak onto a day-30 note: telling an
+	// operator to unpublish in the Console would be wrong advice for a
+	// transient auth failure.
+	require.NotContains(t, reasons[0], "Play Console")
 }

--- a/services/marketplace-api/internal/whitelabel/lifecycle/client_factory.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/client_factory.go
@@ -45,9 +45,11 @@ type AppleTeardownFactory func(ctx context.Context, tenantID, storeID uuid.UUID)
 // also tenant-less — so "wire the real client instead of the fake" is not
 // a one-line swap on this side either.
 //
-// The real client returns googleplay.ErrNotWired from every method, after
-// fetching credentials. That is what production should see: an honest
-// "not implemented", rather than googleplay.FakeClient's silent success.
+// The real client implements day 30 (BlockDownloads halts the production
+// track) and REFUSES day 60: unpublishing a Play listing has no Android
+// Publisher API, so PullApp returns googleplay.ErrUnpublishNotSupported.
+// That is what production should see — an honest refusal the advancer
+// records, rather than googleplay.FakeClient's silent success.
 type GoogleTeardownFactory func(ctx context.Context, tenantID, storeID uuid.UUID) (googleplay.ClientAPI, error)
 
 // NewAppleTeardownFactory builds a real App Store Connect client per

--- a/services/marketplace-api/internal/whitelabel/lifecycle/discovery_test.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/discovery_test.go
@@ -165,7 +165,12 @@ func TestNewAppleListerFactory_PropagatesCredentialErrors(t *testing.T) {
 
 // With GooglePackage empty by design, the advancer's `if
 // r.GooglePackage != ""` guards mean Play is never attempted, never
-// errors and never logs. The row must therefore say so itself.
+// errors and never logs. The row must therefore say so itself — and state
+// BOTH reasons, because they are of different kinds: the missing package
+// identifier is a decision that could be revisited, while the absent
+// unpublish API cannot be. This assertion used to require the word
+// "stub", which the wired client made false; the note now has to name
+// the two real causes instead.
 func TestTeardownCoverage_StatesPlayIsNotAttempted(t *testing.T) {
 	note := teardownCoverage(ProAppCancelledEvent{
 		AppleAppID:        "6448000111",
@@ -174,7 +179,12 @@ func TestTeardownCoverage_StatesPlayIsNotAttempted(t *testing.T) {
 
 	require.Contains(t, note, "google_play=NOT_ATTEMPTED")
 	require.Contains(t, strings.ToLower(note), "no package identifier")
-	require.Contains(t, strings.ToLower(note), "stub")
+	require.Contains(t, strings.ToLower(note), "no android publisher api",
+		"the permanent half of the reason must be stated, not just the missing identifier")
+	require.Contains(t, strings.ToLower(note), "play console",
+		"the note must name the manual action, since no code can perform it")
+	require.NotContains(t, strings.ToLower(note), "errnotwired",
+		"the Play client is wired; a note claiming otherwise is the defect #702 exists to remove")
 	require.Contains(t, note, "apple=will_attempt(app_id=6448000111)")
 	require.Contains(t, note, "merchant-app-42")
 	// A placeholder package would make the guard fire while asserting an
@@ -187,6 +197,10 @@ func TestTeardownCoverage_NamesPlayPackageWhenOneExists(t *testing.T) {
 		AppleAppID:    "1",
 		GooglePackage: "com.merchant.shop",
 	})
-	require.Contains(t, note, "google_play=will_attempt(package=com.merchant.shop)")
+	require.Contains(t, note, "google_play=will_attempt(package=com.merchant.shop")
 	require.NotContains(t, note, "NOT_ATTEMPTED")
+	// "will_attempt" must not read as "the listing will come down": day 30
+	// is all that is attemptable.
+	require.Contains(t, strings.ToLower(note), "day-30 download halt only")
+	require.Contains(t, strings.ToLower(note), "play console")
 }

--- a/services/marketplace-api/internal/whitelabel/lifecycle/pro_app_cancelled_consumer.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/pro_app_cancelled_consumer.go
@@ -239,11 +239,19 @@ func (c *ProAppCancelledConsumer) appendCoverageNote(ctx context.Context, ev Pro
 // WHY THIS EXISTS RATHER THAN A PLACEHOLDER IDENTIFIER: the advancer
 // guards both of its Google calls with `if r.GooglePackage != ""`
 // (advancer.go), and GooglePackage is empty by design — there is no
-// source for it and the Play client is an unimplemented stub. So Play is
-// never attempted, never errors, and never logs: the row would advance
-// all the way to credentials_purged having said nothing whatsoever about
-// Google, which is the same "we report a teardown we never performed"
-// failure this whole path exists to prevent, one level down.
+// source for it. So Play is never attempted, never errors, and never
+// logs: the row would advance all the way to credentials_purged having
+// said nothing whatsoever about Google, which is the same "we report a
+// teardown we never performed" failure this whole path exists to prevent,
+// one level down.
+//
+// TWO SEPARATE REASONS, both stated in the note. The Play client is NOT a
+// stub any more — day 30 halts the production track for real — so the
+// missing package identifier is the only thing stopping day 30. Day 60 is
+// stopped by something no code can lift: unpublishing a Play listing has
+// no Android Publisher API (googleplay.ErrUnpublishNotSupported) and
+// needs a human in the Play Console. A note that named only the stub
+// would be false today AND would hide the permanent half.
 //
 // Filling GooglePackage with a placeholder to make the guard fire would
 // be worse: it trades a silent skip for a row asserting an identifier
@@ -258,12 +266,18 @@ func teardownCoverage(ev ProAppCancelledEvent) string {
 	}
 
 	if ev.GooglePackage != "" {
-		parts = append(parts, fmt.Sprintf("google_play=will_attempt(package=%s)", ev.GooglePackage))
+		// Day 30 only. Naming the halt and the un-pullable listing here is
+		// what stops a reader in ninety days from taking "will_attempt" for
+		// "the listing came down".
+		parts = append(parts, fmt.Sprintf(
+			"google_play=will_attempt(package=%s, day-30 download halt only; day-60 unpublish has no "+
+				"Android Publisher API and requires a manual Play Console action)", ev.GooglePackage))
 	} else {
 		parts = append(parts, "google_play=NOT_ATTEMPTED(no package identifier is discoverable at cancel time, "+
-			"and the Play client is an unimplemented stub returning ErrNotWired; "+
-			"the advancer's day-30 and day-60 Google calls are guarded on google_package "+
-			"and will not run for this row — the merchant's Play listing, if any, stays live)")
+			"so the advancer's day-30 and day-60 Google calls, both guarded on google_package, "+
+			"will not run for this row; and even with a package, day 60 could never complete — "+
+			"unpublishing a Play listing has no Android Publisher API and requires a manual "+
+			"Play Console action — the merchant's Play listing, if any, stays live)")
 	}
 
 	if ev.FirebaseProjectID != "" {

--- a/services/marketplace-api/internal/whitelabel/metrics/metrics.go
+++ b/services/marketplace-api/internal/whitelabel/metrics/metrics.go
@@ -7,6 +7,11 @@
 //   - CredentialAccessed spikes indicate either a CI/CD rebuild cycle or a
 //     credential-dump attempt; alert when the 1m rate exceeds the median
 //     over 24h by a wide margin.
+//   - LifecycleStepSkipped is the ONLY signal that a teardown step did not
+//     happen. LifecycleTransition increments identically whether or not the
+//     third-party call succeeded, so without this counter a Play or Firebase
+//     outage across the whole cohort is invisible to alerting and shows up
+//     only as reason text inside white_label_app_lifecycle rows.
 package metrics
 
 import "github.com/prometheus/client_golang/prometheus"
@@ -39,13 +44,33 @@ var (
 		},
 		[]string{"type"},
 	)
+
+	// LifecycleStepSkipped counts teardown steps the advancer recorded as
+	// NOT performed while still advancing the row. Labels:
+	//   surface — "google_play" | "firebase"
+	//   step    — "block_downloads" | "block_downloads_day60_retry" |
+	//             "pull_app" | "archive_project"
+	//
+	// Both labels are closed sets; do NOT add tenant_id or store_id.
+	//
+	// `pull_app` on google_play is expected to be non-zero forever, not a
+	// fault: unpublishing a Play listing has no API. Alert on the OTHERS
+	// rising, and on a step_skipped rate that tracks the transition rate
+	// (which means the surface is failing for every row, not one).
+	LifecycleStepSkipped = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "white_label_app_lifecycle_step_skipped_total",
+			Help: "Count of white-label teardown steps recorded as not performed, labeled by surface/step.",
+		},
+		[]string{"surface", "step"},
+	)
 )
 
 // MustRegister registers the white-label collectors into the supplied
 // Prometheus registry. Main calls this once at startup; tests can pass a
 // dedicated registry to isolate assertions.
 func MustRegister(reg prometheus.Registerer) {
-	reg.MustRegister(LifecycleTransition, CredentialAccessed)
+	reg.MustRegister(LifecycleTransition, CredentialAccessed, LifecycleStepSkipped)
 }
 
 func init() {
@@ -54,5 +79,5 @@ func init() {
 	// via MustRegister; they will get the "already registered" panic if
 	// they also touch the default — the standard testing idiom is to call
 	// prometheus.Unregister() after; see internal/metrics/registry.go.
-	prometheus.MustRegister(LifecycleTransition, CredentialAccessed)
+	prometheus.MustRegister(LifecycleTransition, CredentialAccessed, LifecycleStepSkipped)
 }


### PR DESCRIPTION
Wires the Android Publisher client for the one teardown step the API allows, and makes the other one say so.

## The day-60 step was never buildable

`internal/whitelabel/googleplay`'s doc comment said `PullApp` "remove[s] the app listing via `edits.tracks.update` flipping state to **unpublished**". Verified against Google's v3 reference:

- there is **no `unpublished` status** — the four values are `draft`, `inProgress`, `halted`, `completed` (and a fifth, `statusUnspecified`)
- `edits.tracks.update` manages releases *within* a track and cannot delist
- `applications` has exactly **one** method, `dataSafety`

**Unpublishing a Play listing has no Android Publisher API.** It is a Play Console action. `edits.listings.delete` and `countryTargeting` were considered and rejected — the reasoning is in the code.

So the reason nobody noticed day 60 was unimplementable is that a comment described a mechanism that does not exist. `PullApp` now returns `ErrUnpublishNotSupported` naming the Console requirement, and never nil.

Day 30 **is** possible: a production release set to `halted` means "APKs will no longer be served to users" — no new installs, existing ones keep working. That is now wired for real: RS256 service-account JWT, `edits.insert` → `tracks.get` → `tracks.update` → `edits.commit`, with `edits.delete` on every failure path after insert. No new dependency — `google.golang.org/api` and `oauth2` were already in `go.mod`; that header note was stale too.

## Two defects found by attacking it, not reading it

**A false claim was being written into the audit record, defended by a passing test.** `teardownCoverage` is not a comment — it is `appendCoverageNote`d into `white_label_app_lifecycle` as the seed-time note, described in the code as "the durable half, still readable in ninety days". It said *"the Play client is an unimplemented stub returning ErrNotWired"*, which this PR makes false. And `discovery_test.go` asserted the note contained `"stub"`, so a green test defended it.

Worse, that assertion was **vacuous**: the Firebase clause contributes the word "stub" to the same string, so it would have passed on a Play clause that never mentioned one. The note now states both real reasons — no discoverable package identifier, and no unpublish API — and the assertion tests the Play clause specifically.

**An unrecognised release status reported success without halting.** `haltServingReleases` switched on four values with no `default:`, so anything else was copied through, `changed` stayed false, the edit was abandoned, and `BlockDownloads` returned **nil** — after which the advancer wrote `downloads_blocked` for an app that may still have been serving. Now a `default:` refuses, "refusing to report a halt that may not have happened". `statusUnspecified` has its own branch.

## Behaviour changes worth knowing

- **Day 30 can now visibly fail for a store rather than silently succeeding.** That is the intended trade, but it is a real change.
- **Day 60 re-attempts the halt before pulling**, recorded under its own `block_downloads_day60_retry` step. The halt is idempotent, so this costs nothing when it already succeeded and turns a transient 503 at day 30 from "a permanently unhalted app" into "halted one tick late". Costs one extra Play round-trip per row per day-60 tick against a per-developer-account quota.
- **`LifecycleStepSkipped{surface,step}`** now exists for both Play and Firebase skips. Previously a failed halt and a successful one emitted the identical `..._transition_total`, so nothing could alert on Play teardown failing across the cohort.
- `googleplay.ErrNotWired` is **deleted**. The package is under `internal/` so nothing external could import it, and `firebase.ErrNotWired` remains live meaning the opposite — the two defects above were that trap firing. A comment now records why this package deliberately has no such sentinel.

## The load-bearing assumption, unverified

`completed` → `halted` is not live-verified and cannot be here. The API documents `halted` as "APKs will no longer be served" and restricts no transitions, but the Play Console only offers "halt rollout" for a staged `inProgress` release. If Play's backend rejects halting a fully-rolled-out release it arrives as a non-auth `*googleapi.Error` and is recorded as "block downloads NOT performed" — visible, now alertable, but a failure. **This is the first thing to test the day a real package name exists.**

Every claim here rests on a fake and an httptest server. Never on Google.

## Testing note that matters

The advancer's tests are behind `//go:build integration` and **silently skip** without `TEST_DATABASE_URL` — `go test ./...` prints `ok` for that package having run none of them. Verified by asserting the count, not the word:

```
TEST_DATABASE_URL=... go test -tags=integration ./internal/whitelabel/lifecycle/ -run TestAdvancer
  14 subtests ran, 0 failures
```

The `googleplay` client tests are deliberately untagged and do run in a plain `go test ./...` (26 cases). Five mutations were each confirmed caught, including reproducing the `err=<nil>` silent success before its fix.

## Still blocked, and not fixed here

Play teardown remains unreachable in production: `discovery.go` leaves `GooglePackage` empty because **nothing produces a package name**. The Publisher API cannot list apps; the only discovery path is Play Developer Reporting `v1beta1 apps:search`, on a different scope whose per-merchant grant is unverifiable from here. The alternative is capturing the package name at credential upload. That decision is still open on #702 — this PR converts "unwired" into "waiting on one input", which is needed under either option.

Deferred: the cleanup-error wording on an already-halted package, `classify` dropping the underlying error so `errors.As` fails, `PullApp`'s first doc line, and a missing production track reading as transient.