### PR TITLE
ci: run every Node gate on 24, and guard against the drift returning (#857)

### DIFF
--- a/.github/scripts/test-ci-contract.py
+++ b/.github/scripts/test-ci-contract.py
@@ -281,6 +281,61 @@ class ReusableCIContract(unittest.TestCase):
             self.assertIn("REDACTED", finding["Secret"])
             self.assertIn("REDACTED", finding["Match"])
 
+    def test_every_node_gate_matches_the_shipped_node_major(self) -> None:
+        """No gate may run a Node major that production does not ship (#857).
+
+        CI ran every Node gate on 22 while the app Dockerfiles ship
+        base-node-*-24, so no gate exercised the runtime that ships -- which
+        had already left two Node-24-only test failures green in CI. The
+        Dockerfile bases are the source of truth here: they are what runs in
+        production, and they are digest-pinned and updated by the base image
+        refresh workflow. Every other Node declaration must agree with them.
+        """
+        majors: dict[str, set[str]] = {}
+
+        def record(label: str, value: str) -> None:
+            majors.setdefault(value, set()).add(label)
+
+        for app in ("admin", "storefront", "onboarding"):
+            dockerfile = (ROOT / f"apps/{app}/Dockerfile").read_text()
+            found = set(re.findall(r"base-node-(?:builder|runtime)-(\d+)@", dockerfile))
+            self.assertNotEqual(
+                found, set(), f"apps/{app}/Dockerfile pins no base-node-* image"
+            )
+            for major in found:
+                record(f"apps/{app}/Dockerfile base-node-*-{major}", major)
+
+        # `node_version:`/`node-version:` in any workflow, and the root
+        # package.json engines floor. Globbing the workflow dir rather than
+        # naming files means a NEW workflow with a Node pin is covered the
+        # day it lands, which is how the drift got in the first time.
+        workflow_dir = ROOT / ".github/workflows"
+        for path in sorted(
+            p
+            for pattern in ("*.yml", "*.yaml")
+            for p in workflow_dir.glob(pattern)
+        ):
+            for major in re.findall(
+                r'^\s*node[_-]version:\s*"?(\d+)', path.read_text(), re.MULTILINE
+            ):
+                record(f"{path.name} node_version", major)
+
+        engines = json.loads((ROOT / "package.json").read_text())["engines"]["node"]
+        engines_major = re.search(r"(\d+)", engines)
+        self.assertIsNotNone(engines_major, f"unparseable engines.node: {engines}")
+        record(f"package.json engines.node ({engines})", engines_major.group(1))
+
+        self.assertEqual(
+            len(majors),
+            1,
+            "Node major drift -- every gate must run the major production "
+            "ships:\n"
+            + "\n".join(
+                f"  {major}: {', '.join(sorted(labels))}"
+                for major, labels in sorted(majors.items())
+            ),
+        )
+
     def test_no_workflow_sets_the_opt_in_operator_flags(self) -> None:
         # mark8ly#834 Task 1 moved 8 opt-in operator scripts to
         # apps/*/tests/operator/ — five of them default to a PRODUCTION

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     uses: tesserix/tesserix-workflows/.github/workflows/nextjs-ci.yml@v2.3.0
     with:
       working_directory: .
-      node_version: "22"
+      node_version: "24"
       legacy_peer_dependencies: true
       audit_workspaces: >-
         @mark8ly/admin

--- a/.github/workflows/e2e-runnable.yml
+++ b/.github/workflows/e2e-runnable.yml
@@ -55,13 +55,15 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
-          # Matches the `node_version: "22"` the Next.js job in ci.yml passes
-          # to tesserix-workflows/nextjs-ci.yml. This job runs `next build`
-          # on the same app that job builds, so a different major here would
-          # mean the build verified by CI and the build these e2e tests run
-          # against were produced by different toolchains. Move both or
-          # neither.
-          node-version: "22"
+          # Matches the `node_version: "24"` the Next.js job in ci.yml passes
+          # to tesserix-workflows/nextjs-ci.yml, which in turn matches the
+          # base-node-*-24 images the app Dockerfiles ship. This job runs
+          # `next build` on the same app that job builds, so a different
+          # major here would mean the build verified by CI and the build
+          # these e2e tests run against were produced by different
+          # toolchains. Move both or neither -- and
+          # .github/scripts/test-ci-contract.py now fails if they diverge.
+          node-version: "24"
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
       - name: Install Playwright Chromium

--- a/.github/workflows/mobile-admin-build.yml
+++ b/.github/workflows/mobile-admin-build.yml
@@ -43,7 +43,7 @@ jobs:
       working_directory: apps/mobile-admin
       install_directory: .
       lockfile_path: package-lock.json
-      node_version: "22"
+      node_version: "24"
       legacy_peer_dependencies: true
       # A tag push builds ANDROID only: mobile-admin-ios-release.yml answers
       # the same tag with a local iOS build, and leaving this at 'all' would

--- a/apps/admin/tests/unit/api/subscription/appCredentials.test.ts
+++ b/apps/admin/tests/unit/api/subscription/appCredentials.test.ts
@@ -9,6 +9,26 @@
  * request body was a FormData instance by checking Content-Type is
  * multipart/form-data (set automatically by the browser/node FormData).
  *
+ * Note on the FormData/Blob/File globals (see #857): this suite runs in the
+ * jsdom environment, which installs jsdom's own FormData, Blob and File over
+ * the Node built-ins. Node's bundled undici -- which implements fetch, and so
+ * both serialises and parses the multipart body -- constructs file parts with
+ * `new File(...)` off the live global but brand-checks them against the `File`
+ * it captured at its own module init, the built-in one. Under jsdom those are
+ * two different classes, with two consequences: serialising a jsdom File loses
+ * its filename (it degrades to a plain Blob part named "blob"), and parsing
+ * the body back fails an internal assertion outright, so
+ * `request.formData()` throws.
+ *
+ * Neither is MSW's doing and neither is a product defect: a bare
+ * `new Request(url, { method: 'POST', body: fd }).formData()` throws the same
+ * assertion under jsdom with no MSW in the picture, and succeeds once the
+ * built-ins are restored. Browsers use the native FormData/Blob/File, so
+ * restoring them here makes this file exercise the same primitives production
+ * does. jsdom is still what resolves the relative request URLs the API client
+ * sends, so the environment stays jsdom; only these three globals are swapped,
+ * and they are put back afterwards.
+ *
  * Tests:
  *   1. Apple 204 — resolves void
  *   2. Apple sends correct multipart fields
@@ -22,6 +42,7 @@
 import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest'
 import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
+import { Blob as NodeBlob, File as NodeFile } from 'node:buffer'
 
 import {
   uploadAppleCredentials,
@@ -35,9 +56,42 @@ import { ApiError } from '@/lib/api/client'
 
 const server = setupServer()
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+// ---------------------------------------------------------------------------
+// Restore the built-in multipart primitives over jsdom's -- see header note
+// ---------------------------------------------------------------------------
+
+const jsdomGlobals = {
+  FormData: globalThis.FormData,
+  Blob: globalThis.Blob,
+  File: globalThis.File,
+}
+
+/**
+ * Node exposes Blob and File from `node:buffer` but FormData only as a global,
+ * which jsdom has already overwritten by the time this file loads. Round-trip
+ * a trivial urlencoded body through the built-in fetch types to get an
+ * instance of the built-in FormData back, and read its constructor off it.
+ */
+async function builtinFormData(): Promise<typeof FormData> {
+  const parsed = await new Response('_=1', {
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+  }).formData()
+  return parsed.constructor as typeof FormData
+}
+
+beforeAll(async () => {
+  globalThis.FormData = await builtinFormData()
+  globalThis.Blob = NodeBlob as unknown as typeof globalThis.Blob
+  globalThis.File = NodeFile as unknown as typeof globalThis.File
+  server.listen({ onUnhandledRequest: 'error' })
+})
 afterEach(() => server.resetHandlers())
-afterAll(() => server.close())
+afterAll(() => {
+  server.close()
+  globalThis.FormData = jsdomGlobals.FormData
+  globalThis.Blob = jsdomGlobals.Blob
+  globalThis.File = jsdomGlobals.File
+})
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -93,9 +147,12 @@ describe('uploadAppleCredentials', () => {
     expect(contentType).toMatch(/multipart\/form-data/)
     expect(formData?.get('issuer_id')).toBe(APPLE_FIXTURE.issuer_id)
     expect(formData?.get('key_id')).toBe(APPLE_FIXTURE.key_id)
-    // p8 sent as a Blob file named 'key.p8'
+    // p8 sent as a file part named 'key.p8', carrying the .p8 text verbatim --
+    // this is what the Go handler reads via c.Request.FormFile("p8").
     const p8Field = formData?.get('p8')
-    expect(p8Field).not.toBeNull()
+    expect(p8Field).toBeInstanceOf(NodeFile)
+    expect((p8Field as File).name).toBe('key.p8')
+    expect(await (p8Field as File).text()).toBe(APPLE_FIXTURE.p8_contents)
   })
 
   it('400 invalid_p8_format — throws ApiError(400)', async () => {
@@ -160,8 +217,12 @@ describe('uploadGoogleCredentials', () => {
 
     await uploadGoogleCredentials(STORE_ID, GOOGLE_FIXTURE)
 
+    // Sent as a file part named 'service-account.json' carrying the JSON
+    // verbatim, not as a plain string field.
     const field = formData?.get('service_account_json')
-    expect(field).not.toBeNull()
+    expect(field).toBeInstanceOf(NodeFile)
+    expect((field as File).name).toBe('service-account.json')
+    expect(await (field as File).text()).toBe(GOOGLE_FIXTURE.service_account_json)
   })
 
   it('400 invalid_service_account_json — throws ApiError(400)', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22141,8 +22141,8 @@
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-14.0.1.tgz",
       "integrity": "sha512-V81FZ7xRUfqM6uSI6FA1KnZ+QpEKnISqafob/xEfcx1ymwhm4V3snuLWWFjmAz+XaZQTqlYa8z3QbqEXz7G63w==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "expo": "*"
       }
@@ -35335,6 +35335,11 @@
         "zustand": "^5.0.0"
       },
       "devDependencies": {
+        "expo-constants": "~17.0.0",
+        "expo-device": "~7.0.0",
+        "expo-haptics": "~14.0.1",
+        "expo-notifications": "~0.29.0",
+        "expo-secure-store": "~14.0.1",
         "typescript": "^5.9.0"
       },
       "peerDependencies": {

--- a/packages/mobile-shared/package.json
+++ b/packages/mobile-shared/package.json
@@ -38,6 +38,11 @@
     "@react-native-firebase/auth": "*"
   },
   "devDependencies": {
+    "expo-constants": "~17.0.0",
+    "expo-device": "~7.0.0",
+    "expo-haptics": "~14.0.1",
+    "expo-notifications": "~0.29.0",
+    "expo-secure-store": "~14.0.1",
     "typescript": "^5.9.0"
   }
 }


### PR DESCRIPTION
Closes #857.

## The gap

Every CI Node gate ran on **22** while the app Dockerfiles ship `base-node-*-24`. So no gate exercised the runtime that ships — and `package.json` already declared `>=24`, meaning CI was running below its own floor.

The failure mode is the wrong way round: a Node-24-only *product* bug would be invisible to every gate and would ship, while a Node-24-only *test* bug is invisible to CI and burns whoever runs the suite locally on the supported version. The second had already happened — two of eight tests in `apps/admin/tests/unit/api/subscription/appCredentials.test.ts` fail on Node 24 and pass on 22.

## The two failures are test-infrastructure, not a product bug — confirmed, not assumed

#857 asked for this to be established rather than believed, and getting the cause right took two attempts.

**My first diagnosis was wrong.** I built the exact FormData `lib/api/subscription/appCredentials.ts` produces — a `Blob`-with-filename plus two `z.string()` fields — round-tripped it through a `Request` in plain Node 24, and it succeeded. I concluded MSW was the interposer. That experiment removed **two** variables at once (MSW *and* jsdom) and I attributed the result to one of them.

**The real cause is jsdom.** `apps/admin/vitest.config.ts:8` sets `environment: "jsdom"`, which overwrites `globalThis.File`. Node's bundled undici captures `File` at its own module init but resolves it live when constructing parsed parts, so the two are different classes and the brand check fails. Proved with **zero MSW involved**: in the jsdom environment a bare `new Request(url, {method:'POST', body: fd}).formData()` throws the identical assertion, and succeeds the moment `globalThis.File` is restored from `node:buffer`.

That also settles the "just bump MSW" option more firmly than a version comparison could: no MSW release can fix a failure MSW is not present for. **No dependency or lockfile change in this PR.**

## Why the raw-body approach was rejected

The obvious alternative was to assert on `await request.text()` instead of MSW's parsed FormData. It would have codified a bug as the contract.

Restoring only `File` surfaced a second jsdom artifact: jsdom's `FormData.append` builds a *jsdom* `File`, undici's serialiser fails the same brand check and degrades the part to `filename="blob"` — so **the filename never reaches the wire under jsdom**. A raw-body assertion would have had to enshrine `filename="blob"` as expected, or drop the filename check entirely.

Instead: restore the three built-in multipart primitives (`FormData`, `Blob`, `File`) for that one file, reverted in `afterAll`. The environment stays jsdom deliberately — `// @vitest-environment node` was tried and all 8 tests fail with `Failed to parse URL from /api/admin/...`, because the client sends relative URLs.

## The tests were also weaker than their own comment claimed

The pre-change file asserted only `expect(p8Field).not.toBeNull()`, while the comment above it claimed the filename was `'key.p8'`. Every row is now strictly stronger — file-part vs string field, exact filename, and verbatim content — and mutation-tested three ways, each failing exactly one test:

- drop the filename → `expected 'blob' to be 'key.p8'`
- send a string instead of a Blob → `not an instance of File`
- truncate the body → content mismatch

## The durable half

Bumping the version fixes today. `test-ci-contract.py` gains `test_every_node_gate_matches_the_shipped_node_major`, which treats the **Dockerfile bases as the source of truth** and globs every workflow, so a gate drifting from the shipped major fails the build. Proved to fail on drift.

Gates moved: `ci.yml:76`, `mobile-admin-build.yml:46`, and `e2e-runnable.yml:66` **plus its comment**, which said it matched ci.yml's 22 and would otherwise have become false. `mobile-admin-ios-release.yml` was already 24. No other pin exists — no `.nvmrc`, one `setup-node` use, no app-level `engines.node`. `ci.yml`'s 181-line cap is untouched.

## Verification

On Node v24.20.0: all 8 `appCredentials` tests pass with both previously-failing ones listed individually by the verbose reporter (not skipped); `apps/admin` 136 files / 1269 tests pass; root `npm test` 4/4 workspace tasks; `test-ci-contract.py` 8/8; prettier and `tsc --noEmit` clean.

## Known limits

- The global swap mutates `globalThis` — locally, reverted, and vitest-isolated. A future tidy-up that drops any one of the three re-breaks the file; the header comment records why each is needed.
- Built-in `FormData` is recovered via `(await new Response(body).formData()).constructor`, since Node exposes it only as a global. Behaviour-based rather than internals-based, but indirect.
- Only this one file parses multipart in tests (swept repo-wide), so this was not generalised into `vitest.setup.ts`. A second such file should trigger extracting a helper.
- The root cause is an upstream Node/undici–jsdom interaction; if fixed upstream the block becomes harmless dead weight.
- Node 24 was exercised locally for `vitest` and `tsc` only. `next build` on 24 and the EAS/Expo build on 24 are first exercised by this PR's own CI — though `mobile-admin-ios-release.yml` has been on 24 already, which is some evidence for the Expo path.


---

## Update: moving to Node 24 immediately found a real bug

CI on the first push went red — and it is the kind of thing #857 exists to surface, so it is worth recording rather than folding in silently.

`@repo/mobile-shared#check-types` failed with `TS2307: Cannot find module 'expo-haptics'`. main was green on its previous three runs, so this is Node-24-specific.

**The mechanism is narrower than "npm 11 hoists differently".** `package-lock.json` marks `node_modules/expo-haptics@14.0.1` `"peer": true` — it exists *solely* to satisfy `mobile-shared`'s peer declaration. CI installs with `npm ci --legacy-peer-deps`, and npm 11 skips peer-marked entries under that flag where npm 10 installed them anyway. That is the entire version difference.

The package's other four expo peers survived for a different reason: **`apps/mobile-storefront` declares them as real, non-peer dependencies**, which the flag never drops. It does not declare `expo-haptics` — only `apps/mobile-admin` does, nested and unreachable. And root `check-types` excludes mobile-admin while including mobile-shared.

So a **shared** package's type-check was resting on a sibling app's hoist.

**Fix:** `packages/mobile-shared` now declares all five expo modules as its own `devDependencies`, pinned to the versions that already resolved so the type-check surface does not move, while keeping them as `peerDependencies` for consumers. All five were verified as imported from type-checked files — the four survivors were the same accident one step removed.

Two escapes were explicitly rejected: excluding `mobile-shared` from `check-types` (hides the bug, strips type coverage from shared code) and pinning npm back to 10 (defeats the PR).

**Lockfile changed — 6 insertions, 1 deletion.** The `"peer": true` → `"dev": true` flip *is* the fix; the rest is the five devDependency lines. Nothing added, removed or version-changed. Verified `npm ci --legacy-peer-deps` (CI's exact command) and plain `npm ci` both resolve from a wiped tree without rewriting the lock. Note for future maintainers: do **not** regenerate this lock with `npm install --legacy-peer-deps` — it prunes every peer-only entry and deletes 44 `@firebase/*` packages.

## A verification hazard worth knowing about

The git worktree used for this work sits *inside* the primary checkout, so Node module resolution walks past the worktree root and finds the primary checkout's `node_modules` two levels up. `tsc --traceResolution` confirmed `expo-haptics` resolving there. **Root `check-types` was green in the worktree even before the fix** — the bug was unreproducible there.

All installs, type-checks and tests were therefore re-run in a `git archive HEAD` export with no `node_modules` in any ancestor directory, which reproduced the CI failure exactly. On Node v24.20.0 / npm 11.19.0 there: root `check-types` 5/5, `mobile-shared` tsc clean with 95/95 tests, `apps/admin` 1269/1269, `test-ci-contract.py` 8/8.

## Deliberately not fixed here

- `react` and `react-native` sit in the same structural position, one degree safer because sibling apps declare them as real dependencies. Pinning `react` risks a nested second copy and duplicate-React type errors — its own change, not a rider on a CI fix.
- **A larger latent instance of #857:** `mobile-shared` type-checks against mobile-storefront's SDK-52 expo family (17.0.8 / 7.0.3 / 0.29.14 / 14.0.1) while `apps/mobile-admin` ships `expo-*@~56`. Shared code has never been type-checked against the API surface it actually runs on in admin.
- `--legacy-peer-deps` remains in force, so any *new* peer-only dependency of any workspace fails identically. Dropping the flag is the stronger fix and a much larger change.
- `@react-native-firebase/auth` is a declared peer that nothing in the package imports — possibly stale.
