### PR TITLE
ci: allowlist four advisories that cannot be patched until the Expo SDK conflict is resolved (#864)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,9 +104,48 @@ jobs:
       # set is listed, so metro/react-native picking up anything unrelated
       # still fails. Revisit on the next react-native bump: drop these two
       # ids and see whether the chain has been patched upstream.
+      #
+      # ── TEMPORARY, tracked by mark8ly#864 ────────────────────────────────
+      #
+      # Four advisories published 2026-09-08 that DO have published fixes and
+      # still cannot be applied. `main` passed at 17:03 on an unchanged
+      # lockfile and every PR failed from ~00:00, blocking work that touches
+      # no dependency at all.
+      #
+      # Unlike image-size above, these are allowlisted because the LOCKFILE
+      # cannot currently be regenerated, not because there is nothing to
+      # upgrade to:
+      #
+      #   - Generating with `--legacy-peer-deps` silently DROPS peer deps. A
+      #     no-op regeneration removes ~50 packages — `@tiptap/pm` and
+      #     `expo-haptics` vanish — and the admin suite then dies on
+      #     `Cannot find package '@tiptap/pm'`. (`npm ci --legacy-peer-deps`,
+      #     what this workflow runs, is safe: it honours the lock as written.)
+      #   - Generating WITHOUT it is clean (+1/-48) until a version actually
+      #     changes, at which point it fails on an Expo SDK conflict: the
+      #     workspace spans SDK 52 (mobile-storefront), 56 and 57
+      #     (mobile-admin), and their peer ranges cannot all be satisfied.
+      #
+      # So the fix is a multi-app Expo reconciliation, not a version bump.
+      # #864 carries the evidence and the four ruled-out approaches.
+      #
+      # The `next` entry is a CRITICAL and this should be short-lived. Exposure
+      # is bounded: all three are patched-in-range, so removing these five ids
+      # is the FIRST thing to try once #864 lands — not a later cleanup.
+      #
+      #   next          16.2.11 -> 16.3.4   critical
+      #   @tiptap/core  3.22.5  -> 3.30.5+  high, admin editor only
+      #   js-yaml       -> 3.15.2 / 4.3.2   high, transitive
+      #   sharp         0.35.3  -> 0.35.4   high, transitive
       audit_allowlist: >-
         GHSA-w3rx-r6r6-pgpr
         GHSA-5p2g-fcmc-qvqq
+        GHSA-2xp9-vwfh-vxw4
+        GHSA-p293-qw3h-jr36
+        GHSA-rgj7-g3m4-5g8c
+        GHSA-cp6q-959q-f8rh
+        GHSA-j95f-988m-3j2f
+        GHSA-2883-xcg3-v3hh
     secrets:
       package_read_token: ${{ secrets.GHCR_PAT }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,47 +105,21 @@ jobs:
       # still fails. Revisit on the next react-native bump: drop these two
       # ids and see whether the chain has been patched upstream.
       #
-      # ── TEMPORARY, tracked by mark8ly#864 ────────────────────────────────
+      # TEMPORARY — four advisories published 2026-09-08, tracked by #864.
       #
-      # Four advisories published 2026-09-08 that DO have published fixes and
-      # still cannot be applied. `main` passed at 17:03 on an unchanged
-      # lockfile and every PR failed from ~00:00, blocking work that touches
-      # no dependency at all.
+      # Unlike image-size above these DO have in-range fixes; they cannot be
+      # applied because the lockfile cannot currently be regenerated.
+      # Generating with --legacy-peer-deps silently drops peer deps (a no-op
+      # regen loses ~50 packages incl. @tiptap/pm and expo-haptics, breaking
+      # the admin suite); generating without it fails on an Expo SDK conflict
+      # in apps/mobile-admin. `npm ci --legacy-peer-deps` stays safe — it
+      # honours the lock as written. #864 has the evidence.
       #
-      # Unlike image-size above, these are allowlisted because the LOCKFILE
-      # cannot currently be regenerated, not because there is nothing to
-      # upgrade to:
-      #
-      #   - Generating with `--legacy-peer-deps` silently DROPS peer deps. A
-      #     no-op regeneration removes ~50 packages — `@tiptap/pm` and
-      #     `expo-haptics` vanish — and the admin suite then dies on
-      #     `Cannot find package '@tiptap/pm'`. (`npm ci --legacy-peer-deps`,
-      #     what this workflow runs, is safe: it honours the lock as written.)
-      #   - Generating WITHOUT it is clean (+1/-48) until a version actually
-      #     changes, at which point it fails on an Expo SDK conflict: the
-      #     workspace spans SDK 52 (mobile-storefront), 56 and 57
-      #     (mobile-admin), and their peer ranges cannot all be satisfied.
-      #
-      # So the fix is a multi-app Expo reconciliation, not a version bump.
-      # #864 carries the evidence and the four ruled-out approaches.
-      #
-      # The `next` entry is a CRITICAL and this should be short-lived. Exposure
-      # is bounded: all three are patched-in-range, so removing these five ids
-      # is the FIRST thing to try once #864 lands — not a later cleanup.
-      #
-      #   next          16.2.11 -> 16.3.4   critical
-      #   @tiptap/core  3.22.5  -> 3.30.5+  high, admin editor only
-      #   js-yaml       -> 3.15.2 / 4.3.2   high, transitive
-      #   sharp         0.35.3  -> 0.35.4   high, transitive
+      # `next` is a CRITICAL. Removing these five ids is the FIRST thing to
+      # try once #864 lands, not a later cleanup.
       audit_allowlist: >-
-        GHSA-w3rx-r6r6-pgpr
-        GHSA-5p2g-fcmc-qvqq
-        GHSA-2xp9-vwfh-vxw4
-        GHSA-p293-qw3h-jr36
-        GHSA-rgj7-g3m4-5g8c
-        GHSA-cp6q-959q-f8rh
-        GHSA-j95f-988m-3j2f
-        GHSA-2883-xcg3-v3hh
+        GHSA-w3rx-r6r6-pgpr GHSA-5p2g-fcmc-qvqq GHSA-2xp9-vwfh-vxw4 GHSA-p293-qw3h-jr36
+        GHSA-rgj7-g3m4-5g8c GHSA-cp6q-959q-f8rh GHSA-j95f-988m-3j2f GHSA-2883-xcg3-v3hh
     secrets:
       package_read_token: ${{ secrets.GHCR_PAT }}
 


### PR DESCRIPTION
Unblocks every PR in the repo. One file, allowlist entries only, no dependency change.

## The situation

Four advisories published 2026-09-08 are failing the audit gate on **every** PR, including ones that touch no dependency at all (#859 changes one test-setup file; #863 changes workflows and one test). `main` passed at 17:03 on an unchanged lockfile and PRs began failing from ~00:00 — npm's feed picking up new advisories, the same thing `ci.yml` already documents for `image-size`.

```
critical: next         GHSA-2xp9-vwfh-vxw4, GHSA-p293-qw3h-jr36, GHSA-rgj7-g3m4-5g8c
high:     @tiptap/core GHSA-cp6q-959q-f8rh, GHSA-j95f-988m-3j2f
high:     js-yaml      GHSA-2883-xcg3-v3hh
high:     sharp        GHSA-rgj7-g3m4-5g8c
```

## Why these are allowlisted rather than fixed

**Unlike `image-size`, all four have published in-range fixes.** They still cannot be applied, because the lockfile cannot currently be regenerated — established by measurement, not assumption:

- **Generating with `--legacy-peer-deps` silently drops peer dependencies.** A **no-op** regeneration removes ~50 packages: `@tiptap/pm` and `expo-haptics` disappear, `@repo/mobile-shared#check-types` fails, and the admin suite dies on `Cannot find package '@tiptap/pm'`. (`npm ci --legacy-peer-deps`, what this workflow runs, is safe — it honours the lock as written. Only *generation* is destructive.)
- **Generating without it is clean** — `+1/-48`, every peer preserved — until a version actually changes, at which point it fails on an Expo SDK conflict.

The workspace spans **three Expo majors**: `mobile-storefront` on SDK 52, `mobile-admin` on 56 with three packages stranded on 57 (`expo-router`, `expo-linking`, `expo-web-browser`). I reconciled mobile-admin's three strays to 56 and resolution succeeded there — then the conflict surfaced in `mobile-storefront` instead. It is a multi-app migration, not a version bump, and not something to land inside a security patch.

#864 carries the full evidence and the four approaches ruled out (`overrides`, `install-strategy=hoisted`, moving the tiptap family, from-scratch regeneration).

## This should be short-lived

The `next` entry is a **critical**, and the comment says so at the allowlist. All four are patched-in-range, so removing these five ids is the **first** thing to try once #864 lands — not a later cleanup. That is written into the file rather than left to memory.

Exposure while it stands: `@tiptap/core` is the admin page-body editor (authenticated merchant, own content); `js-yaml` and `sharp` are transitive; `next` is the one that matters and is the reason this is framed as temporary.

## Verification

YAML parses. The gate tolerates a vulnerability only when its complete advisory set is listed, so anything new in these packages still fails — the existing property is preserved.
