### PR TITLE
docs(whitelabel): state what day 60 does on Play, and give the operator the step

### DIFF
--- a/docs/runbooks/white-label-app-lifecycle.md
+++ b/docs/runbooks/white-label-app-lifecycle.md
@@ -112,8 +112,77 @@ If confirmed benign (no merchants sunsetting), silence via
 Alertmanager for 7 days. Re-check weekly — the silence is not a fix,
 just noise reduction.
 
+## Day 60 on Google Play — a manual step, every time, forever
+
+**This is not a stall and force-advancing will not help.** It is the one
+teardown step the platform cannot perform, and it needs a person in the
+Play Console.
+
+### The signal
+
+```promql
+increase(white_label_app_lifecycle_step_skipped_total{surface="google_play",step="pull_app"}[24h]) > 0
+```
+
+Each increment is one merchant whose Play listing is still live after the
+platform finished its day-60 work. Unlike every other counter here, **this one
+rising is the expected steady state, not a fault** — see the note in
+`metrics.go`. Alert on the *other* surfaces rising; treat this one as a work
+queue.
+
+The matching audit row records the reason rather than asserting a success. It is in
+the append-only log (`white_label_app_lifecycle`), which is the table with a `reason`
+column — `white_label_app_state` is the mutable current-state row and carries no
+failure text:
+
+```sql
+SELECT l.tenant_id, l.store_id, l.created_at, l.reason, s.google_package
+  FROM white_label_app_lifecycle l
+  LEFT JOIN white_label_app_state s ON s.store_id = l.store_id
+ WHERE l.status = 'pulled'
+   AND l.reason LIKE '%requires a manual Play Console unpublish%'
+ ORDER BY l.created_at;
+```
+
+The `LIKE` matches the exact suffix `advancer.go` appends when the cause is
+`googleplay.ErrUnpublishNotSupported`, so a row that failed for any *other* Play
+reason will not be picked up here — that one is a genuine fault and belongs in the
+stuck-row diagnosis above.
+
+### Why the platform cannot do it
+
+The Android Publisher v3 API has no unpublish. There is no `unpublished`
+release status (`draft`, `inProgress`, `halted`, `completed`,
+`statusUnspecified`), `edits.tracks.update` only manages releases *within* a
+track, and the `applications` resource has exactly one method, `dataSafety`.
+`googleplay.Client.PullApp` returns `ErrUnpublishNotSupported` rather than
+claiming a success it did not earn. See tesserix/mark8ly#862.
+
+### The manual step
+
+1. Confirm the merchant is genuinely at day 60 — check `scheduled_at` on
+   `white_label_app_state` (the sunset anchor the advancer counts from), not the
+   alert alone. Note `merchant_initiated = true` compresses the schedule to 7 days,
+   so day 60 arrives sooner for those rows.
+2. Play Console -> the merchant's app -> **Advanced settings -> App
+   availability -> Unpublish**.
+3. Record it against the merchant. There is no automated confirmation, so an
+   unrecorded action is indistinguishable from one nobody did.
+
+Apple needs nothing here: `apple.Client.PullApp` removes the app through App
+Store Connect and the day-60 transition completes on its own.
+
+### If the counter is zero and you expected work
+
+Neither Play step can run in production yet — `discovery.go` leaves
+`GooglePackage` empty because nothing captures a package identifier. Until
+that is decided, both the day-30 halt and this day-60 step are unreachable and
+the counter stays flat. That is a known gap, not evidence the teardown worked.
+
 ## References
 
 - `services/marketplace-api/internal/whitelabel/lifecycle/advancer.go`
-- Spec §13.5
+- `services/marketplace-api/internal/whitelabel/googleplay/client.go` — `ErrUnpublishNotSupported`
+- `services/marketplace-api/internal/whitelabel/metrics/metrics.go` — why the skip counter is expected to rise
+- Spec §13.5, including the day-60 correction note
 - Migration `000076_white_label_app_state`

--- a/docs/superpowers/specs/2026-04-17-subscription-model-design.md
+++ b/docs/superpowers/specs/2026-04-17-subscription-model-design.md
@@ -533,9 +533,30 @@ When a Pro+App merchant cancels or churns, the apps cannot just vanish — their
 |---|---|
 | 0 | Cancellation confirmed. Push notification disabled (Firebase project placed in read-only). |
 | 7 | In-app banner deploys: "Service ending in 53 days. Contact [merchant email] for questions." |
-| 30 | New downloads blocked (app marked unavailable in both stores). Existing users still open app; storefront shows "Store closed" page. |
-| 60 | App pulled from both stores. Firebase project archived. Existing installs show static "service ended" screen on launch. |
+| 30 | New downloads blocked (Apple: unavailable in all territories. Play: production release `halted`). Existing users still open app; storefront shows "Store closed" page. |
+| 60 | **Apple:** app removed. **Play: the listing stays up — not automatable, requires a person (see the note below).** Firebase project archived. Existing installs show static "service ended" screen on launch. |
 | 90 | Firebase project deleted. App removed from tenant's Apple/Google accounts (optional — merchant decides). |
+
+> **Day 60 on Google Play has no API, and this table used to claim otherwise.**
+>
+> Verified against the Android Publisher v3 reference on 2026-09-09 (#862): there is no
+> `unpublished` release status — the values are `draft`, `inProgress`, `halted`,
+> `completed`, `statusUnspecified`. `edits.tracks.update` manages releases *within* a
+> track and cannot delist, and the `applications` resource has exactly one method,
+> `dataSafety`. `edits.listings.delete` and `countryTargeting` were both considered and
+> rejected. Unpublishing is a Play Console action performed by a person.
+>
+> `googleplay.Client.PullApp` therefore returns `ErrUnpublishNotSupported` rather than
+> reporting a success it did not earn (#860), and the advancer records the skip as
+> `white_label_app_lifecycle_step_skipped_total{surface="google_play",step="pull_app"}`.
+> **That counter rising is the expected steady state, not a fault** — it is the signal an
+> operator acts on, and `docs/runbooks/white-label-app-lifecycle.md` carries the manual
+> step.
+>
+> Nothing merchant-facing has ever asserted the stronger promise — this table was the only
+> place it appeared, so it is corrected here rather than walked back with customers. That
+> is only possible because it was caught before the day-60 path became reachable: nothing
+> produces a Play package identifier yet, so neither Play step runs in production today.
 
 **Merchant-initiated immediate pull**: merchant can request accelerated teardown. Apps pulled within 7 days, Firebase archived immediately.
 


### PR DESCRIPTION
Closes #862 by doing both of its options, because measuring where the promise actually lives made the choice between them unnecessary.

## The promise was never merchant-facing

#862 frames this as a customer-facing promise that has to be narrowed or upheld. It is neither, yet: grepping `apps/admin`, `apps/onboarding` and `apps/storefront` for cancellation and teardown copy turns up **nothing** about the app listing. The only day-60 text a merchant can see is about data retention on store closure, which is unrelated.

"Day 60 — App pulled from both stores" exists in exactly two places: **§13.5 of the subscription spec**, and internal log strings.

So option 2 ("narrow the promise") is not walking something back with customers — it is correcting a spec **before** it becomes a promise. That is only possible because #862 was filed before the day-60 path became reachable: `discovery.go` leaves `GooglePackage` empty, so neither Play step runs in production today.

That in turn makes option 1 affordable rather than competing: the operator obligation can be written down without also owning a retraction.

## What changed

**§13.5's lifecycle table now describes the system.** Day 30 distinguishes Apple (unavailable in all territories) from Play (production release `halted`). Day 60 says the Apple app is removed and **the Play listing stays up, requiring a person**. A note beneath records the API constraint, the `ErrUnpublishNotSupported` behaviour from #860, and why the skip counter rising is the expected steady state rather than a fault.

**The runbook gains the step it was missing.** `white-label-app-lifecycle.md` covered *stuck* lifecycles only — it had no section for the one step that is permanently manual, so the metric #860 added had no instruction attached to it. It now has the PromQL, the audit query, the Play Console path, and an explicit "this is not a stall, force-advancing will not help".

## Verified against the schema and the emitted string, not written from the issue

The first draft of that audit query was wrong in three ways, and all three are the kind that fail silently at 3am:

- `white_label_app_state` has **`status`**, not `lifecycle_state`
- it has **no `last_error`** — the failure text lives on the append-only `white_label_app_lifecycle`, which is the table with a `reason` column (000048 vs 000076)
- there is no `sunset_started_at`; the sunset anchor is **`scheduled_at`**

The query now joins the two tables correctly, and its `LIKE` matches the exact suffix `advancer.go:288` appends when the cause is `googleplay.ErrUnpublishNotSupported` — so a Play failure for any *other* reason is deliberately not caught here, because that one is a genuine fault belonging in the stuck-row section above. `appendNote` was read to confirm it writes `status` and `reason` the way the query reads them.

The runbook also now notes that `merchant_initiated = true` compresses the schedule to 7 days, so "is it really day 60?" has a different answer for those rows.

## Not included, deliberately

The **`GooglePackage` capture decision** — #702's other orphan, which #862 correctly points out is tracked nowhere since #702 closed. It is a real decision (capture at credential upload, versus the Play Developer Reporting API's beta `v1beta1 apps:search` on a different scope) and it deserves its own issue rather than holding this one open. Filed as #872.
