### PR TITLE
feat(whitelabel): capture the Play package name at credential upload, so the day-30 halt can run

### DIFF
--- a/services/marketplace-api/internal/billing/appcreds/paths.go
+++ b/services/marketplace-api/internal/billing/appcreds/paths.go
@@ -30,6 +30,23 @@ const (
 	// CredTypeGooglePlayJSON is the Google Play Android Publisher
 	// service-account JSON (not a user OAuth credential).
 	CredTypeGooglePlayJSON CredType = "google-play-service-account"
+
+	// CredTypeGooglePackageName is the merchant's Android applicationId
+	// (e.g. "com.example.app").
+	//
+	// NOT A SECRET, and stored here anyway — following
+	// CredTypeAppleIssuerID, which is likewise a plain identifier. The
+	// reason is the choke-point in this package's doc comment: every read
+	// and write emits an audit event and a Prometheus counter, and the
+	// secret name embeds the tenant id, so tenant isolation is structural
+	// rather than a WHERE clause someone can forget. A new column on some
+	// other table would have neither property.
+	//
+	// It exists because Play, unlike App Store Connect, has no discovery
+	// endpoint: the Android Publisher API is edit-scoped, so every call
+	// needs the package name you are asking about and nothing can
+	// enumerate them (tesserix/mark8ly#872).
+	CredTypeGooglePackageName CredType = "google-play-package-name"
 )
 
 // AllCredTypes returns every CredType in a stable order. This is the
@@ -41,6 +58,7 @@ func AllCredTypes() []CredType {
 		CredTypeAppleIssuerID,
 		CredTypeAppleKeyID,
 		CredTypeGooglePlayJSON,
+		CredTypeGooglePackageName,
 	}
 }
 

--- a/services/marketplace-api/internal/billing/appcreds/paths_test.go
+++ b/services/marketplace-api/internal/billing/appcreds/paths_test.go
@@ -39,8 +39,8 @@ func TestPath_MatchesSpec18_9(t *testing.T) {
 // CredType without adding it here would leak a credential past teardown.
 func TestAllCredTypes_Enumerated(t *testing.T) {
 	got := AllCredTypes()
-	if len(got) != 4 {
-		t.Errorf("AllCredTypes() len = %d, want 4", len(got))
+	if len(got) != 5 {
+		t.Errorf("AllCredTypes() len = %d, want 5", len(got))
 	}
 	// Must contain each known CredType exactly once.
 	seen := make(map[CredType]int)
@@ -49,6 +49,7 @@ func TestAllCredTypes_Enumerated(t *testing.T) {
 	}
 	want := []CredType{
 		CredTypeAppleP8, CredTypeAppleIssuerID, CredTypeAppleKeyID, CredTypeGooglePlayJSON,
+		CredTypeGooglePackageName,
 	}
 	for _, ct := range want {
 		if seen[ct] != 1 {
@@ -87,6 +88,7 @@ func TestAllCredTypes_StableOrder(t *testing.T) {
 		"apple-asc-issuer-id":         true,
 		"apple-asc-key-id":            true,
 		"google-play-service-account": true,
+		"google-play-package-name":    true,
 	}
 	for _, s := range gotStrs {
 		if !wantSet[s] {

--- a/services/marketplace-api/internal/billing/appcreds/validate.go
+++ b/services/marketplace-api/internal/billing/appcreds/validate.go
@@ -7,6 +7,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"regexp"
 )
 
 // ErrInvalidP8 is returned when a .p8 payload is not a PEM-wrapped,
@@ -19,6 +20,10 @@ var ErrInvalidP8 = errors.New("appcreds: invalid .p8 (expected PEM PKCS#8 ECDSA 
 // a service-account JSON (e.g. user OAuth credentials, invalid JSON, or
 // missing required fields).
 var ErrInvalidGooglePlayJSON = errors.New("appcreds: invalid Google Play service-account JSON")
+
+// ErrInvalidGooglePackageName is returned when a supplied Android
+// applicationId is not a legal package name.
+var ErrInvalidGooglePackageName = errors.New("appcreds: invalid Google Play package name")
 
 // ValidateP8 asserts the payload is a PEM-wrapped PKCS#8 ECDSA P-256
 // private key. Returns a wrapped ErrInvalidP8 on failure. Does NOT persist
@@ -117,4 +122,57 @@ func GooglePlayProjectID(payload []byte) (string, error) {
 		return "", err
 	}
 	return sa.ProjectID, nil
+}
+
+// googlePackageNameRe is Android's applicationId grammar: two or more
+// dot-separated segments, each a legal Java identifier — a leading letter
+// followed by letters, digits or underscores.
+//
+// ANCHORED AT BOTH ENDS, and `\A`/`\z` rather than `^`/`$`, because Go's
+// `$` matches before a trailing newline. A package name pasted out of a
+// build file arrives as "com.example.app\n" more often than not, and `^...$`
+// would accept it — storing a name the Android Publisher API then rejects.
+var googlePackageNameRe = regexp.MustCompile(`\A[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+\z`)
+
+// maxGooglePackageNameLen matches white_label_app_state.google_package
+// (varchar(255), migration 000076). Validating shorter than the column
+// would reject legal names; validating longer would accept one that
+// truncates on write, and a truncated package is a package Play does not
+// know — the advancer would call it nightly and fail.
+const maxGooglePackageNameLen = 255
+
+// ValidateGooglePackageName checks a merchant-supplied Android
+// applicationId.
+//
+// # Why this is validated at all, when it is only an identifier
+//
+// It is the one white-label credential with no self-describing format: a
+// .p8 is parsed as a key and a service-account JSON is parsed as JSON, so
+// both fail loudly on garbage. A package name is just a string, and a
+// wrong one is INDISTINGUISHABLE FROM A RIGHT ONE until it reaches Play.
+//
+// That matters because of where it is used. `lifecycle/advancer.go` guards
+// both Google calls on `r.GooglePackage != ""` — a typo is non-empty, so it
+// passes the guard, reaches `edits.insert` inside the nightly cron, and
+// surfaces only as a skipped teardown step for one merchant, months later,
+// at the moment the teardown was supposed to happen. Refusing it at the
+// upload boundary is the only place a human is present to fix it.
+//
+// It deliberately does NOT verify the package exists in Play. That would
+// need an API call with the merchant's credential at upload time, and a
+// merchant may legitimately supply the name before the app is published.
+func ValidateGooglePackageName(name string) error {
+	if len(name) > maxGooglePackageNameLen {
+		return fmt.Errorf("%w: %d bytes exceeds the %d-byte column",
+			ErrInvalidGooglePackageName, len(name), maxGooglePackageNameLen)
+	}
+	if !googlePackageNameRe.MatchString(name) {
+		// The name is NOT echoed into the error. It reaches an HTTP response
+		// and a log line, and while a package name is not a secret it is
+		// attacker-controlled input on an authenticated endpoint — the same
+		// reason the sibling validators return a fixed sentinel.
+		return fmt.Errorf("%w: expected two or more dot-separated segments, "+
+			"each starting with a letter (e.g. com.example.app)", ErrInvalidGooglePackageName)
+	}
+	return nil
 }

--- a/services/marketplace-api/internal/billing/appcreds/validate_test.go
+++ b/services/marketplace-api/internal/billing/appcreds/validate_test.go
@@ -180,3 +180,61 @@ func TestGooglePlayProjectID_RejectsWhatValidateRejects(t *testing.T) {
 		})
 	}
 }
+
+// ValidateGooglePackageName — the Android applicationId a merchant supplies
+// alongside their Play service account (#872).
+//
+// The rules are Android's, not ours, and the reason to pin them in a test is
+// that a wrong package name FAILS SILENTLY in the place it matters: the
+// advancer guards its Play calls on `google_package != ""`, so a typo'd name
+// is non-empty, passes the guard, and fails at `edits.insert` inside a nightly
+// cron — visible only as a skipped teardown step for one merchant.
+func TestValidateGooglePackageName(t *testing.T) {
+	valid := []string{
+		"com.mark8ly.storefront",
+		"com.example.app_two",
+		"a.b",
+		"com.example.sub.deep.nesting",
+		"com.example.a1b2",
+	}
+	for _, in := range valid {
+		if err := ValidateGooglePackageName(in); err != nil {
+			t.Errorf("ValidateGooglePackageName(%q) = %v, want nil", in, err)
+		}
+	}
+
+	invalid := map[string]string{
+		"":                   "empty",
+		"com":                "single segment — Android requires at least one dot",
+		"com.":               "trailing dot leaves an empty segment",
+		".com.example":       "leading dot leaves an empty segment",
+		"com..example":       "empty middle segment",
+		"com.example.":       "trailing dot",
+		"com.1example":       "segment starting with a digit",
+		"com.example.my-app": "hyphen is not a legal Java identifier char",
+		"com.example.my app": "space",
+		"com.example.app\n":  "trailing newline, the classic copy-paste artefact",
+		" com.example.app":   "leading space, likewise",
+		"COM.EXAMPLE.APP\t":  "trailing tab",
+	}
+	for in, why := range invalid {
+		if err := ValidateGooglePackageName(in); err == nil {
+			t.Errorf("ValidateGooglePackageName(%q) = nil, want error (%s)", in, why)
+		} else if !errors.Is(err, ErrInvalidGooglePackageName) {
+			t.Errorf("ValidateGooglePackageName(%q) = %v, want ErrInvalidGooglePackageName", in, err)
+		}
+	}
+}
+
+// Length is bounded because the column is varchar(255) (migration 000076).
+// A name that validates here and truncates on write would be a package the
+// advancer calls Play with and Play does not recognise.
+func TestValidateGooglePackageNameLength(t *testing.T) {
+	long := "com.example." + string(make([]byte, 0))
+	for len(long) <= 255 {
+		long += "a"
+	}
+	if err := ValidateGooglePackageName(long); err == nil {
+		t.Errorf("ValidateGooglePackageName(len %d) = nil, want error", len(long))
+	}
+}

--- a/services/marketplace-api/internal/handlers/admin/app_credentials.go
+++ b/services/marketplace-api/internal/handlers/admin/app_credentials.go
@@ -182,6 +182,7 @@ func (h *AppCredentialsHandler) PostApple(c *gin.Context) {
 //	POST /admin/stores/:storeId/app-credentials/google
 //	multipart/form-data:
 //	  - service_account_json (file)
+//	  - package_name         (optional text — the Android applicationId)
 func (h *AppCredentialsHandler) PostGoogle(c *gin.Context) {
 	tenantID, storeID, ok := h.appAddOnGate(c)
 	if !ok {
@@ -206,6 +207,27 @@ func (h *AppCredentialsHandler) PostGoogle(c *gin.Context) {
 		return
 	}
 
+	// OPTIONAL, and it has to be — this endpoint is behind `appAddOnGate`,
+	// which requires an ACTIVE Pro+App subscription. The sale therefore
+	// strictly precedes this upload, so there is no earlier point at which a
+	// package name could be required, and making it mandatory here would only
+	// lock existing merchants out of re-uploading their service account
+	// (tesserix/mark8ly#872).
+	//
+	// Validated BEFORE the JSON is stored, so a bad name cannot leave the
+	// service account written and the package rejected — a partial write the
+	// merchant would have to discover by re-uploading.
+	packageName := strings.TrimSpace(c.Request.FormValue("package_name"))
+	if packageName != "" {
+		if err := appcreds.ValidateGooglePackageName(packageName); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error":  "invalid_package_name",
+				"detail": "expected an Android applicationId such as com.example.app",
+			})
+			return
+		}
+	}
+
 	actor := "user:" + c.GetString("user_id")
 	if err := h.credsSvc.Store(c.Request.Context(), appcreds.StoreInput{
 		TenantID: tenantID, StoreID: storeID,
@@ -213,6 +235,20 @@ func (h *AppCredentialsHandler) PostGoogle(c *gin.Context) {
 	}); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "store_failed"})
 		return
+	}
+
+	// Second, and only after the service account landed: the package name is
+	// useless without it, so an order that could leave a package name with no
+	// credential beside it would be the worse half to keep.
+	if packageName != "" {
+		if err := h.credsSvc.Store(c.Request.Context(), appcreds.StoreInput{
+			TenantID: tenantID, StoreID: storeID,
+			CredType: appcreds.CredTypeGooglePackageName,
+			Payload:  []byte(packageName), Actor: actor,
+		}); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "store_failed"})
+			return
+		}
 	}
 	c.Status(http.StatusNoContent)
 }

--- a/services/marketplace-api/internal/handlers/admin/app_credentials_test.go
+++ b/services/marketplace-api/internal/handlers/admin/app_credentials_test.go
@@ -13,6 +13,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -319,5 +320,102 @@ func TestAppAddOnGate_SubRepoError(t *testing.T) {
 	// Fail-closed: repo error → 403 add_on_not_active, not 500.
 	if w.Code != http.StatusForbidden {
 		t.Errorf("status = %d, want 403 (fail-closed)", w.Code)
+	}
+}
+
+// validGoogleSA is the shape PostGoogle accepts; the package-name tests below
+// vary only the package_name field so a failure names the field it is about.
+func validGoogleSA() []byte {
+	return []byte(`{
+	  "type":"service_account","project_id":"proj",
+	  "private_key":"-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----",
+	  "client_email":"sa@proj.iam.gserviceaccount.com"
+	}`)
+}
+
+func postGoogle(t *testing.T, fields map[string]any) (*httptest.ResponseRecorder, *appcreds.FakeSM, uuid.UUID) {
+	t.Helper()
+	tenantID, storeID, userID := uuid.New(), uuid.New(), uuid.New()
+	fake := appcreds.NewFakeSM()
+	svc := appcreds.NewService(appcreds.Config{ProjectID: "p", SM: fake, Emitter: nil})
+	repo := &fakeSubRepo{sub: &subscription.StoreSubscription{
+		TenantID: tenantID, StoreID: storeID,
+		Plan: subscription.PlanPro, HasWhiteLabelAppAddOn: true,
+	}}
+	h := NewAppCredentialsHandler(nil, repo, svc)
+
+	body, ct := makeMultipart(t, fields)
+	req := httptest.NewRequest(http.MethodPost, "/admin/stores/"+storeID.String()+"/app-credentials/google", body)
+	req.Header.Set("Content-Type", ct)
+	w := httptest.NewRecorder()
+	router(h, tenantID, userID).ServeHTTP(w, req)
+	return w, fake, tenantID
+}
+
+// package_name — the optional Android applicationId (#872).
+
+func TestPostGoogle_StoresPackageName(t *testing.T) {
+	w, fake, tenantID := postGoogle(t, map[string]any{
+		"service_account_json": validGoogleSA(),
+		"package_name":         "com.example.storefront",
+	})
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body: %s", w.Code, w.Body.String())
+	}
+	name := appcreds.Path("p", tenantID.String(), appcreds.CredTypeGooglePackageName)
+	if !fake.Has(name) {
+		t.Fatalf("package name not stored at %s", name)
+	}
+}
+
+func TestPostGoogle_PackageNameIsOptional(t *testing.T) {
+	// It HAS to be optional: this endpoint is behind appAddOnGate, which
+	// requires an active Pro+App subscription, so the sale always precedes
+	// the upload and no earlier point could have required a package name.
+	// Requiring it here would also lock existing merchants out of
+	// re-uploading their service account.
+	w, fake, tenantID := postGoogle(t, map[string]any{
+		"service_account_json": validGoogleSA(),
+	})
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body: %s", w.Code, w.Body.String())
+	}
+	if fake.Has(appcreds.Path("p", tenantID.String(), appcreds.CredTypeGooglePackageName)) {
+		t.Error("no package name was supplied; nothing should have been written for it")
+	}
+	if !fake.Has(appcreds.Path("p", tenantID.String(), appcreds.CredTypeGooglePlayJSON)) {
+		t.Error("the service account must still be stored")
+	}
+}
+
+func TestPostGoogle_RejectsMalformedPackageName(t *testing.T) {
+	// And critically: rejects it WITHOUT storing the service account, so a
+	// merchant never has to discover a half-applied upload by retrying.
+	for _, bad := range []string{"com", "com.example.my-app", "com.1example", "not a package"} {
+		t.Run(bad, func(t *testing.T) {
+			w, fake, tenantID := postGoogle(t, map[string]any{
+				"service_account_json": validGoogleSA(),
+				"package_name":         bad,
+			})
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+			}
+			if fake.Has(appcreds.Path("p", tenantID.String(), appcreds.CredTypeGooglePlayJSON)) {
+				t.Error("service account was stored despite the request being rejected")
+			}
+		})
+	}
+}
+
+func TestPostGoogle_PackageNameErrorNamesTheField(t *testing.T) {
+	// The service-account failure already answers "invalid_service_account_json".
+	// A package-name failure answering the same thing would send a merchant to
+	// re-export a credential that was fine.
+	w, _, _ := postGoogle(t, map[string]any{
+		"service_account_json": validGoogleSA(),
+		"package_name":         "nope",
+	})
+	if got := w.Body.String(); !strings.Contains(got, "invalid_package_name") {
+		t.Errorf("body = %s, want it to name invalid_package_name", got)
 	}
 }

--- a/services/marketplace-api/internal/whitelabel/lifecycle/advancer.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/advancer.go
@@ -326,9 +326,15 @@ func (a *Advancer) appleClient(ctx context.Context, r Row) (AppleTeardownClient,
 //
 // Unlike appleClient, a failure here is tolerated by the callers: Play
 // teardown is only partly possible — day 30 works, day 60 has no API at
-// all — and rows carry no GooglePackage by design (#702 decision 4), so
-// this path is unreached today. The asymmetry is deliberate: Apple stalls,
-// Play warns AND records what it did not do (recordGoogleSkip).
+// all. The asymmetry is deliberate: Apple stalls, Play warns AND records
+// what it did not do (recordGoogleSkip).
+//
+// THIS PATH IS REACHABLE SINCE #872. It previously could not run at all —
+// rows carried no GooglePackage because nothing produced one (#702
+// decision 4) — and this comment said so. The optional `package_name` on
+// the Play credential upload is now that source, so a row belonging to a
+// merchant who supplied one reaches here for real. Rows without a package
+// still skip the guard in the callers and never arrive.
 func (a *Advancer) googleClient(ctx context.Context, r Row) (googleplay.ClientAPI, error) {
 	if a.google == nil {
 		return nil, fmt.Errorf("lifecycle: no Google client factory configured (store %s carries package %s)",

--- a/services/marketplace-api/internal/whitelabel/lifecycle/discovery.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/discovery.go
@@ -96,15 +96,23 @@ func (d *Discovery) discover(ctx context.Context, tenantID, storeID uuid.UUID) (
 		return ProAppCancelledEvent{}, err
 	}
 
-	// GooglePackage is deliberately left empty (decision 4): there is no
-	// source for it, and inventing a placeholder to satisfy the
-	// advancer's `if r.GooglePackage != ""` guards would seed a row that
-	// claims an identifier it does not have. The row's Play coverage is
-	// stated explicitly instead — see teardownCoverage.
+	// GooglePackage comes from the merchant, via the optional
+	// `package_name` field on the Play credential upload (#872). It is
+	// still frequently EMPTY and that stays a first-class state: the
+	// field is optional because the upload sits behind an active
+	// Pro+App subscription, so no earlier point could have required it,
+	// and every merchant onboarded before #872 has none.
+	//
+	// The original reasoning holds for the empty case and is why nothing
+	// substitutes a placeholder here: the advancer guards both Google
+	// calls on `r.GooglePackage != ""`, so a fabricated value would seed
+	// a row claiming an identifier nobody has. The absence is stated in
+	// words instead — see teardownCoverage.
 	ev := ProAppCancelledEvent{
 		TenantID:          tenantID,
 		StoreID:           storeID,
 		AppleAppID:        appleID,
+		GooglePackage:     d.discoverGooglePackage(ctx, tenantID, storeID, log),
 		FirebaseProjectID: d.discoverFirebaseProjectID(ctx, tenantID, storeID, log),
 	}
 	return ev, nil
@@ -137,6 +145,49 @@ func (d *Discovery) discoverAppleAppID(ctx context.Context, tenantID, storeID uu
 // returns its project_id. Failures are logged and yield "" rather than
 // failing the whole discovery: a missing Firebase project makes the
 // teardown narrower, not wrong, and the row states the narrowing.
+// discoverGooglePackage reads the merchant-supplied Android applicationId.
+//
+// Best-effort, exactly like discoverFirebaseProjectID beside it: an absent
+// or unreadable package narrows what the teardown can do but does not make
+// the row a lie, and teardownCoverage renders the narrowing. Failing the
+// whole discovery here would cost the merchant their APPLE teardown too,
+// which is the larger half and entirely unrelated.
+//
+// Re-validated on read rather than trusted from the write. The value is
+// stored as a Secret Manager payload and may have been written by an older
+// image, or by hand during an incident; a malformed one reaching
+// GooglePackage would pass the advancer's non-empty guard and fail against
+// Play inside a nightly cron. Cheap check, and the only other place a human
+// could notice is months later in a skipped-step counter.
+func (d *Discovery) discoverGooglePackage(ctx context.Context, tenantID, storeID uuid.UUID, log *slog.Logger) string {
+	if d.Creds == nil {
+		log.WarnContext(ctx, "lifecycle/discovery: no credential loader; google package not discovered",
+			"store_id", storeID)
+		return ""
+	}
+	payload, err := d.Creds.Load(ctx, appcreds.LoadInput{
+		TenantID: tenantID,
+		StoreID:  storeID,
+		CredType: appcreds.CredTypeGooglePackageName,
+		Actor:    discoveryActor,
+	})
+	if err != nil {
+		// Expected for every merchant who never supplied one, so this is
+		// Info rather than Warn: at Warn it would fire on the majority of
+		// rows and train readers to skip it.
+		log.InfoContext(ctx, "lifecycle/discovery: no google package name on file",
+			"store_id", storeID, "err", err)
+		return ""
+	}
+	name := strings.TrimSpace(string(payload))
+	if err := appcreds.ValidateGooglePackageName(name); err != nil {
+		log.WarnContext(ctx, "lifecycle/discovery: stored google package name is not valid; treating as absent",
+			"store_id", storeID, "err", err)
+		return ""
+	}
+	return name
+}
+
 func (d *Discovery) discoverFirebaseProjectID(ctx context.Context, tenantID, storeID uuid.UUID, log *slog.Logger) string {
 	if d.Creds == nil {
 		log.WarnContext(ctx, "lifecycle/discovery: no credential loader; firebase project id not discovered",

--- a/services/marketplace-api/internal/whitelabel/lifecycle/discovery_test.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/discovery_test.go
@@ -204,3 +204,69 @@ func TestTeardownCoverage_NamesPlayPackageWhenOneExists(t *testing.T) {
 	require.Contains(t, strings.ToLower(note), "day-30 download halt only")
 	require.Contains(t, strings.ToLower(note), "play console")
 }
+
+// GooglePackage — the merchant-supplied Android applicationId (#872).
+//
+// Before #872 this was empty by design, so these tests are the first
+// coverage that the day-30 Play halt can ever become reachable.
+
+func TestDiscover_GooglePackage_WhenSupplied(t *testing.T) {
+	creds := &stubCreds{byType: map[appcreds.CredType][]byte{
+		appcreds.CredTypeGooglePlayJSON:    []byte(serviceAccountJSON),
+		appcreds.CredTypeGooglePackageName: []byte("com.example.storefront"),
+	}}
+	ev, err := discoveryWith([]apple.App{{ID: "123"}}, nil, creds).
+		discover(context.Background(), uuid.New(), uuid.New())
+
+	require.NoError(t, err)
+	require.Equal(t, "com.example.storefront", ev.GooglePackage)
+}
+
+func TestDiscover_GooglePackage_AbsentIsNotAnError(t *testing.T) {
+	// The majority case, and it must stay a first-class state: the upload
+	// sits behind an active Pro+App subscription, so every merchant
+	// onboarded before #872 has none. Apple's teardown is the larger half
+	// and must not be lost with it.
+	creds := &stubCreds{byType: map[appcreds.CredType][]byte{
+		appcreds.CredTypeGooglePlayJSON: []byte(serviceAccountJSON),
+	}}
+	ev, err := discoveryWith([]apple.App{{ID: "123"}}, nil, creds).
+		discover(context.Background(), uuid.New(), uuid.New())
+
+	require.NoError(t, err)
+	require.Empty(t, ev.GooglePackage)
+	require.Equal(t, "123", ev.AppleAppID, "apple teardown must survive an absent package")
+}
+
+func TestDiscover_GooglePackage_MalformedIsTreatedAsAbsent(t *testing.T) {
+	// The value is a Secret Manager payload that an older image or a
+	// hand-edit during an incident could have written. A malformed one
+	// reaching GooglePackage would pass the advancer's `!= ""` guard and
+	// fail against Play inside the nightly cron — months later, visible
+	// only as a skipped step. Re-validating on read is what stops that,
+	// and dropping to empty is strictly better than seeding a lie.
+	creds := &stubCreds{byType: map[appcreds.CredType][]byte{
+		appcreds.CredTypeGooglePlayJSON:    []byte(serviceAccountJSON),
+		appcreds.CredTypeGooglePackageName: []byte("not a package name"),
+	}}
+	ev, err := discoveryWith([]apple.App{{ID: "123"}}, nil, creds).
+		discover(context.Background(), uuid.New(), uuid.New())
+
+	require.NoError(t, err)
+	require.Empty(t, ev.GooglePackage)
+}
+
+func TestDiscover_GooglePackage_IsTrimmed(t *testing.T) {
+	// Package names are copy-pasted out of build files, and a trailing
+	// newline is the usual artefact. It is rejected at upload, but a value
+	// written before #872's validator existed would still carry one.
+	creds := &stubCreds{byType: map[appcreds.CredType][]byte{
+		appcreds.CredTypeGooglePlayJSON:    []byte(serviceAccountJSON),
+		appcreds.CredTypeGooglePackageName: []byte("  com.example.app\n"),
+	}}
+	ev, err := discoveryWith([]apple.App{{ID: "123"}}, nil, creds).
+		discover(context.Background(), uuid.New(), uuid.New())
+
+	require.NoError(t, err)
+	require.Equal(t, "com.example.app", ev.GooglePackage)
+}

--- a/services/marketplace-api/internal/whitelabel/lifecycle/pro_app_cancelled_consumer.go
+++ b/services/marketplace-api/internal/whitelabel/lifecycle/pro_app_cancelled_consumer.go
@@ -238,12 +238,21 @@ func (c *ProAppCancelledConsumer) appendCoverageNote(ctx context.Context, ev Pro
 //
 // WHY THIS EXISTS RATHER THAN A PLACEHOLDER IDENTIFIER: the advancer
 // guards both of its Google calls with `if r.GooglePackage != ""`
-// (advancer.go), and GooglePackage is empty by design — there is no
-// source for it. So Play is never attempted, never errors, and never
-// logs: the row would advance all the way to credentials_purged having
-// said nothing whatsoever about Google, which is the same "we report a
-// teardown we never performed" failure this whole path exists to prevent,
-// one level down.
+// (advancer.go). When the guard does not fire, Play is never attempted,
+// never errors, and never logs: the row would advance all the way to
+// credentials_purged having said nothing whatsoever about Google, which is
+// the same "we report a teardown we never performed" failure this whole
+// path exists to prevent, one level down.
+//
+// SINCE #872 THERE IS A SOURCE, AND IT IS STILL OFTEN ABSENT. This comment
+// used to say GooglePackage was "empty by design — there is no source for
+// it", which was true until the optional `package_name` field landed on the
+// Play credential upload. The field is optional because that upload sits
+// behind an active Pro+App subscription (`appAddOnGate`), so no earlier
+// point could have required it, and every merchant onboarded before #872
+// has none. So an empty package is now an ORDINARY state rather than the
+// only state — which makes stating it on the row more important, not less:
+// two rows that look identical may differ in whether Play was reachable.
 //
 // TWO SEPARATE REASONS, both stated in the note. The Play client is NOT a
 // stub any more — day 30 halts the production track for real — so the
@@ -273,7 +282,8 @@ func teardownCoverage(ev ProAppCancelledEvent) string {
 			"google_play=will_attempt(package=%s, day-30 download halt only; day-60 unpublish has no "+
 				"Android Publisher API and requires a manual Play Console action)", ev.GooglePackage))
 	} else {
-		parts = append(parts, "google_play=NOT_ATTEMPTED(no package identifier is discoverable at cancel time, "+
+		parts = append(parts, "google_play=NOT_ATTEMPTED(no package identifier on file for this store "+
+			"(the optional package_name on the Play credential upload was never supplied), "+
 			"so the advancer's day-30 and day-60 Google calls, both guarded on google_package, "+
 			"will not run for this row; and even with a package, day 60 could never complete — "+
 			"unpublishing a Play listing has no Android Publisher API and requires a manual "+


### PR DESCRIPTION
Closes #872. Also settles the open product question it ended on — the code answered it.

## The question answered itself

#872 ended asking whether a Pro+App subscription should be **sellable** with no package name on file. It cannot be gated on that, and the reason is structural rather than a preference:

`PostGoogle` sits behind `appAddOnGate` (`app_credentials.go:58`), which requires an **active Pro+App subscription** before a merchant may upload anything. The sale strictly precedes the upload, so there is no earlier point at which a package name could be demanded. Requiring it here would only lock existing merchants out of re-uploading a service account.

So the field is optional, and an empty package stays a first-class state.

## What this adds

- **`CredTypeGooglePackageName`**, following `CredTypeAppleIssuerID` — which is likewise a plain, non-secret identifier stored through `appcreds`. That is not incidental: the package's choke-point emits an audit event and a Prometheus counter on every read and write, and the secret name embeds the tenant id so isolation is structural rather than a `WHERE` clause someone can forget. A column on another table would have neither property.
- **`ValidateGooglePackageName`** — Android's applicationId grammar, anchored `\A…\z` rather than `^…$` **because Go's `$` matches before a trailing newline**, and a package name pasted out of a build file arrives as `com.example.app\n` more often than not.
- **An optional `package_name` field** on `POST …/app-credentials/google`, validated *before* the service account is written so a bad name cannot leave a half-applied upload.
- **`discoverGooglePackage`** in the teardown discovery, best-effort exactly like `discoverFirebaseProjectID` beside it.

## Two things that were easy to get wrong

**`AllCredTypes()` is the day-90 purge order.** Its own comment says a new type "MUST extend this list", and the guard test failed the moment I added the const — which is the test doing its job. Missing it would have left the package name behind after `PurgeAll`.

**A bad package name fails silently in the worst place.** The advancer guards both Play calls on `r.GooglePackage != ""`, so a typo is non-empty, passes the guard, reaches `edits.insert` inside the nightly cron, and surfaces months later as one merchant's skipped teardown step. Hence validation at the upload boundary (where a human is present to fix it) **and** re-validation on read — the stored value could have been written by an older image or by hand during an incident.

## Comments this made false, corrected

Two places asserted the old world, and both would have invited a wrong change:

- `teardownCoverage` said GooglePackage was *"empty by design — there is no source for it"*. There is now, and an empty package is an ordinary state rather than the only one — which makes stating it on the row more important, not less, since two rows that look identical may differ in whether Play was reachable.
- `googleClient` said the path "is unreached today". It is reachable now for merchants who supplied a name.

## Verification

- Full `marketplace-api` suite green; `go build ./...`, `go vet` and `gofmt` clean.
- **9 new tests.** Validator (valid/invalid/length, including the trailing-newline and hyphen cases); discovery (supplied, absent, malformed-treated-as-absent, trimmed); handler (stores it, optional, rejects malformed **without storing the service account**, and names `invalid_package_name` rather than reusing the service-account error).
- **Mutation-tested**, committed first so nothing could be lost: dropping the handler validation, dropping the discovery re-validation, and dropping the `TrimSpace` each turn the suite red; the restored baseline is green.

## Scope

This makes the **day-30 halt** reachable — a cancelling merchant's app stops accepting new installs. Day 60 remains a manual Play Console action (#862/#871); nothing here changes that, and `teardownCoverage` still says so on every row.
