### PR TITLE
Drop a healthcheck a distroless runtime can never pass (#858)

### DIFF
--- a/apps/onboarding/tests/unit/dev-stack-config.spec.ts
+++ b/apps/onboarding/tests/unit/dev-stack-config.spec.ts
@@ -86,6 +86,73 @@ test('no docker-compose service uses a bare command: ["up"]', () => {
   }
 });
 
+// A distroless runtime cannot run a shell-based healthcheck (#858).
+//
+// marketplace-api declared `test: ["CMD", "wget", ...]` while its runtime
+// stage is base-distroless-static, which ships no shell, wget or curl. The
+// probe could never pass, so the container sat permanently `unhealthy` while
+// serving 200s -- and nothing noticed, because the service could not start
+// at all until #875. The real cost is downstream: a
+// `condition: service_healthy` on such a service blocks forever.
+//
+// The compose file already records this for openfga in prose. This makes it
+// a rule, derived from each service's actual runtime base.
+test("no service with a distroless runtime declares a shell healthcheck", () => {
+  const yml = readFileSync(join(root, "infra/dev/docker-compose.yml"), "utf8");
+  const offenders: string[] = [];
+
+  for (const m of yml.matchAll(
+    /^ {2}([a-z0-9-]+):\n((?: {4}\S.*\n| {4,}.*\n|\n)*)/gm,
+  )) {
+    const service = m[1];
+    const body = m[2];
+    if (!service || !body) continue;
+    if (!/^ {4}healthcheck:/m.test(body)) continue;
+
+    const probe = body.match(/^ {6}test:\s*(.+)$/m)?.[1] ?? "";
+    if (!/wget|curl|CMD-SHELL/.test(probe)) continue;
+
+    // Which Dockerfile backs this service, if any? Services built from a
+    // published image (postgres:15-alpine) are fine -- they have a shell.
+    const context = body.match(/^ {6}context:\s*(\S+)/m)?.[1];
+    if (!context) continue;
+    // `dockerfile:` is relative to the CONTEXT, not to the compose file.
+    // Resolving it against infra/dev instead made every read throw, and the
+    // catch below swallowed it -- the first version of this test passed
+    // against the very defect it was written for.
+    const dockerfileRel =
+      body.match(/^ {6}dockerfile:\s*(\S+)/m)?.[1] ?? "Dockerfile";
+
+    let dockerfile: string;
+    try {
+      dockerfile = readFileSync(
+        join(root, "infra/dev", context, dockerfileRel),
+        "utf8",
+      );
+    } catch {
+      continue; // the build-context test above owns unreadable Dockerfiles
+    }
+
+    // The stage the service runs: `target:`, else the final FROM.
+    const target = body.match(/^ {6}target:\s*(\S+)/m)?.[1];
+    const stages = [
+      ...dockerfile.matchAll(/^FROM\s+(\S+)(?:\s+AS\s+(\S+))?/gm),
+    ];
+    const stage = target
+      ? stages.find((f) => f[2] === target)
+      : stages[stages.length - 1];
+    if (!stage) continue;
+
+    if (/distroless/.test(stage[1] ?? "")) {
+      offenders.push(
+        `${service}: healthcheck runs ${probe.trim()} but its runtime stage is ${stage[1]} (no shell/wget/curl)`,
+      );
+    }
+  }
+
+  expect(offenders.join("\n")).toBe("");
+});
+
 // Every compose build context must be able to see what its Dockerfile
 // COPYs (#858).
 //

--- a/infra/dev/docker-compose.yml
+++ b/infra/dev/docker-compose.yml
@@ -226,11 +226,14 @@ services:
         condition: service_completed_successfully
     ports:
       - "8091:8091"
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:8091/health"]
-      interval: 5s
-      timeout: 3s
-      retries: 30
+    # No healthcheck: the runtime stage is base-distroless-static, which has
+    # no shell, wget or curl -- same reason openfga above declares none. The
+    # wget probe that used to sit here could never pass, so the container sat
+    # permanently `unhealthy` while serving 200s. Nothing noticed because the
+    # service could not start at all until #875. Anything that needs to wait
+    # for this service must poll http://localhost:8091/health from outside,
+    # as .github/workflows/e2e-onboarding.yml already does for platform-api;
+    # a `condition: service_healthy` on it would block forever.
 
 volumes:
   postgres-data:


### PR DESCRIPTION
Follow-up to #875, and a correction to a claim I made in it.

## The defect

`marketplace-api` sat permanently **`unhealthy`** in `docker ps` while serving `200` on `/health`:

```
dev-marketplace-api-1   Up 18 minutes (unhealthy)
$ curl -o /dev/null -w '%{http_code}' localhost:8091/health
200
```

Its healthcheck is `test: ["CMD", "wget", "-qO-", ...]`, and its runtime stage is `base-distroless-static` — **no shell, no wget, no curl**:

```
OCI runtime exec failed: exec: "wget": executable file not found in $PATH
```

The probe could never have passed. Nobody saw it because the service could not start at all until #875 — the compose file even records this exact trap two services higher up: *"No healthcheck: openfga image is distroless, has no shell/wget/curl."*

`platform-api` and `auth-bff` are on the same base and correctly declare no healthcheck. `marketplace-api` was the only one.

## Why it matters beyond cosmetics

A `depends_on: { marketplace-api: { condition: service_healthy } }` would **block forever**. Stage 3 wires auth-bff and the admin app against this service, so this would have surfaced there as an unexplained hang.

Removed, with the reasoning and the correct alternative in place (poll `/health` from outside, as `e2e-onboarding.yml` already does for platform-api).

## Correction to #875

#875's verification table said the Tier C stack was "postgres, OpenFGA, platform-api, **marketplace-api** all healthy". The `200` was real and measured; "healthy" was not — the container was reporting `unhealthy` at that moment and I read the HTTP probe rather than the container state. The service was fine; my description of it was wrong.

## The guard, and the fact that it didn't work the first time

New contract test: no compose service whose runtime stage is distroless may declare a shell-based healthcheck. Derived from each service's actual `target:` stage in its own Dockerfile, so it covers services that do not exist yet.

**The first version of this test passed against the very defect it was written for.** It resolved `dockerfile:` relative to `infra/dev` when compose resolves it relative to the **context** — every `readFileSync` threw, and the `catch { continue }` swallowed it, so no service was ever checked. Caught only by running the revert-proof, which is the entire reason for running one.

Fixed version, proven to bite:

```
marketplace-api: healthcheck runs ["CMD", "wget", "-qO-", "http://localhost:8091/health"]
  but its runtime stage is ghcr.io/tesserix/base-distroless-static@sha256:2fea7c... (no shell/wget/curl)
```

## Verification

| check | result |
|---|---|
| container health state after the fix | **`<none>`** — correct for distroless |
| `curl localhost:8091/health` | 200 |
| onboarding unit suite | 120 passed |
| `npm run check-types` | 5/5 |
| new guard against reverted defect | fails, naming service + probe + base image |
| the other 7 dev-stack guards | still pass |
