### PR TITLE
Stand up Zitadel in the dev stack, and get all 7 onboarding specs passing (#858)

### DIFF
--- a/.github/workflows/e2e-onboarding.yml
+++ b/.github/workflows/e2e-onboarding.yml
@@ -18,25 +18,22 @@ env:
 # the merge. It also means this workflow can never again reach main without
 # having executed: the PR that changes it is a PR that runs it.
 #
-# Pinned to three spec files that are fully clean (commit ddd361ac repaired
-# the two that had drifted):
-#   - tests/e2e/form-validation.spec.ts    — 2 passed, 0 failed
-#   - tests/e2e/invalid-token.spec.ts      — 1 passed, 0 failed
-#   - tests/e2e/tax-id-migration.spec.ts   — 4 passed, 5 SKIPPED, 0 failed
-# The 5 skips in tax-id-migration are the migration-UI tests, which skip
-# themselves while MIGRATION_UI_ENABLED is false
-# (apps/onboarding/.../OnboardingForm.tsx:43) — that's a deliberate flag
-# check, not a failure, and the skip is derived from the flag's real value
-# at test time, so flipping the flag on later revives them.
+# Runs the WHOLE onboarding suite: all 7 spec files, 16 tests, gated on
+# exactly 11 passed and 5 skipped.
 #
-# testMatch selects whole files, so any file with even one failing test is
-# excluded wholesale rather than picking individual passing tests out of it
-# — the same file-granularity e2e-runnable.yml uses for pricing.spec.ts.
-# The four remaining onboarding specs — cross-device-verify.spec.ts,
-# golden-path.spec.ts, resume.spec.ts, slug-collision.spec.ts — are excluded
-# because every test in them needs Zitadel to complete set-password →
-# welcome, which arrives in a later stage of #858. That exclusion stays
-# deliberate and visible here, not silent.
+# The 5 skips are tax-id-migration's migration-UI tests, which skip
+# themselves while MIGRATION_UI_ENABLED is false
+# (apps/onboarding/.../OnboardingForm.tsx:43) — a deliberate flag check
+# derived from the flag's real value at test time, so flipping the flag on
+# revives them AND changes the count, which this job then refuses.
+#
+# #858 stage 3 removed the previous three-spec pin. The four excluded
+# specs (cross-device-verify, golden-path, resume, slug-collision) needed
+# Zitadel to get past set-password → /welcome, which this stack now
+# provides. All four turned out to ALSO carry spec drift that only a real
+# run could surface: a required name field they never filled, a password
+# that failed the policy, a renamed welcome CTA, and one asserting a
+# submit button disables when it deliberately does not.
 # =============================================================================
 on:
   # Keep these two path lists identical. A path that can break the suite but
@@ -87,7 +84,7 @@ jobs:
         # has started shipping a postgres and this needs the same treatment.
         run: |
           touch infra/dev/.env.local
-          make dev-min
+          make dev-zitadel
 
       - name: Prove the backend is reachable, not merely running
         # A stack that is "up" but unseeded renders /onboarding as a 500 and
@@ -105,6 +102,23 @@ jobs:
           store=$(curl -fsS http://localhost:8089/stores | jq -r '.stores[] | select(.name=="mark8ly-platform") | .id')
           [ -n "$store" ] \
             || { echo "::error::openfga store mark8ly-platform missing — openfga-seed did not run"; exit 1; }
+          # Zitadel resolves the instance from the Host header; without it
+          # every request 404s "Instance not found" no matter how healthy
+          # the process is. Assert with the header the stack actually uses.
+          curl -fsS -H 'Host: zitadel:8080' http://localhost:8092/debug/healthz >/dev/null \
+            || { echo "::error::zitadel not ready"; docker compose -f infra/dev/docker-compose.yml logs zitadel; exit 1; }
+          # The bootstrap's output is what platform-api reads. An empty or
+          # missing file means it silently started with ZITADEL_ENABLED
+          # false and every set-password submit would stall at 500.
+          grep -q '^ZITADEL_ADMIN_PROJECT_ID=[0-9]' infra/dev/.env.zitadel \
+            || { echo "::error::zitadel bootstrap produced no admin project id"; cat infra/dev/.env.zitadel; exit 1; }
+          # platform-api must reach marketplace-api by its COMPOSE name. On
+          # the k8s default it fails DNS three times per onboarding (~20s)
+          # and leaves the store with no trial clock — the suite still
+          # passes, just slowly, so this is asserted rather than observed.
+          docker compose -f infra/dev/docker-compose.yml exec -T platform-api \
+            printenv MARKETPLACE_API_URL 2>/dev/null | grep -q '^http://marketplace-api:' \
+            || echo "::warning::MARKETPLACE_API_URL is not the compose name; onboarding will be slow and trial-less"
 
       - name: Install dependencies
         run: npm ci
@@ -170,15 +184,15 @@ jobs:
         run: |
           set -o pipefail
           status=0
-          out=$(CI=true npx playwright test tests/e2e/form-validation.spec.ts tests/e2e/invalid-token.spec.ts tests/e2e/tax-id-migration.spec.ts --reporter=line 2>&1) || status=$?
+          out=$(CI=true npx playwright test --reporter=line 2>&1) || status=$?
           printf '%s\n' "$out"
           fail=0
           if [ "$status" -ne 0 ]; then
             echo "::error::playwright exited $status"
             fail=1
           fi
-          grep -qE '(^|[^0-9])7 passed' <<<"$out" || {
-            echo "::error::did not see exactly 7 passed — the onboarding suite is not actually executing and passing"
+          grep -qE '(^|[^0-9])11 passed' <<<"$out" || {
+            echo "::error::did not see exactly 11 passed — the onboarding suite is not actually executing and passing"
             fail=1
           }
           if grep -qE '(^|[^0-9])[0-9]+ (failed|timed out)' <<<"$out"; then

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ k8s/secrets.yaml
 
 # Per-developer local port overrides for the dev stack (task-1 e2e baseline)
 infra/dev/docker-compose.override.yml
+
+# Written by infra/dev/zitadel-bootstrap.py at stack-up time (#858).
+infra/dev/.env.zitadel
+infra/dev/.pat.tmp

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,27 @@ dev-min: ## Bring up the Tier-B stack (postgres, OpenFGA, platform-api) with no 
 	$(COMPOSE) up -d postgres openfga-migrate openfga openfga-seed \
 	                platform-api-migrate platform-api-seed platform-api
 
+dev-zitadel: ## Bring up the Tier-D stack (dev-min + Zitadel, bootstrapped) with no GCP access
+	$(COMPOSE) up -d postgres zitadel
+	@# Zitadel writes the PAT during setup, not at container start: on a cold
+	@# volume it runs ~40 migrations first. Reading the file before then gets
+	@# "No such file or directory". Wait on healthz, which is only served once
+	@# setup has completed -- and send the Host header, or it 404s forever.
+	@printf 'waiting for zitadel'
+	@for i in $$(seq 1 80); do \
+		if [ "$$(curl -s -o /dev/null -w '%{http_code}' -H 'Host: zitadel:8080' \
+			http://localhost:8092/debug/healthz)" = "200" ]; then echo " ready"; break; fi; \
+		printf '.'; sleep 3; \
+	done
+	@docker run --rm -v $$(docker volume ls -q -f name=zitadel-pat | head -1):/pat alpine \
+		cat /pat/pat > infra/dev/.pat.tmp
+	python3 infra/dev/zitadel-bootstrap.py \
+		--pat-file infra/dev/.pat.tmp --env-out infra/dev/.env.zitadel
+	@rm -f infra/dev/.pat.tmp
+	$(COMPOSE) up -d openfga-migrate openfga openfga-seed \
+	                platform-api-migrate platform-api-seed platform-api \
+	                marketplace-api-migrate marketplace-api
+
 dev-down: ## Stop the local stack
 	$(COMPOSE) down
 

--- a/apps/onboarding/tests/e2e/cross-device-verify.spec.ts
+++ b/apps/onboarding/tests/e2e/cross-device-verify.spec.ts
@@ -71,11 +71,16 @@ test("magic link works in a fresh browser context (cross-device)", async ({
   await expect(bPage).toHaveURL(/\/onboarding\/set-password/, {
     timeout: 15_000,
   });
+  await bPage.locator("#name").fill(details.name);
   await bPage.locator("#password").fill(details.password);
   await bPage.getByRole("button", { name: /create account/i }).click();
   await expect(bPage).toHaveURL(/\/welcome/, { timeout: 15_000 });
+  // "Sign in to your admin", not "Open admin dashboard": no session is
+  // minted for the admin origin during onboarding, so the CTA is a sign-in
+  // hand-off (WelcomeCta.tsx). This spec predated that change and had never
+  // run, so it still asserted the old label.
   await expect(
-    bPage.getByRole("link", { name: /open admin dashboard/i }),
+    bPage.getByRole("link", { name: /sign in to your admin/i }),
   ).toBeVisible();
 
   await b.close();

--- a/apps/onboarding/tests/e2e/golden-path.spec.ts
+++ b/apps/onboarding/tests/e2e/golden-path.spec.ts
@@ -17,7 +17,7 @@ test("golden path: landing → form → magic link → welcome", async ({
   page,
   request,
 }) => {
-  const { email, slug, businessName, password } = uniqueEmail();
+  const { email, slug, businessName, password, name } = uniqueEmail();
 
   // 1. Landing page renders and the primary CTA goes to /onboarding.
   await page.goto("/");
@@ -78,6 +78,7 @@ test("golden path: landing → form → magic link → welcome", async ({
   await expect(page).toHaveURL(/\/onboarding\/set-password/, {
     timeout: 15_000,
   });
+  await page.locator("#name").fill(name);
   await page.locator("#password").fill(password);
   await page.getByRole("button", { name: /create account/i }).click();
   await expect(page).toHaveURL(/\/welcome/, { timeout: 15_000 });

--- a/apps/onboarding/tests/e2e/helpers.ts
+++ b/apps/onboarding/tests/e2e/helpers.ts
@@ -17,12 +17,20 @@ export const API_URL =
  * part so it stays under 63 chars and matches the slug regex.
  *
  * Phase M added a required password field on the signup form, so each
- * generated identity also carries a default e2e password. */
+ * generated identity also carries a default e2e password.
+ *
+ * #858 stage 3 added `name`. The set-password form requires it -- Zitadel
+ * needs a givenName/familyName and platform-api splits this single field to
+ * get them. These four specs were written before that field existed and had
+ * never once run, so they submitted a blank name and sat on
+ * "Your name is required" forever, which reads as a broken backend. */
 export function uniqueEmail(label = "e2e"): {
   email: string;
   slug: string;
   businessName: string;
   password: string;
+  /** Submitted on the set-password step; split into givenName/familyName. */
+  name: string;
 } {
   const stamp = `${Date.now().toString(36)}${Math.floor(
     Math.random() * 1e4,
@@ -32,7 +40,14 @@ export function uniqueEmail(label = "e2e"): {
     email: `${local}@example.com`,
     slug: local.replace(/[^a-z0-9-]/g, "").slice(0, 60),
     businessName: `${label} ${stamp}`,
-    password: "e2e-test-password-123",
+    // Must satisfy apps/onboarding/lib/auth/password-policy.ts: >=12 chars
+    // with upper, lower, digit AND symbol. The old value had neither an
+    // uppercase letter nor a symbol, so every set-password submit bounced
+    // on the policy message -- invisible until these specs first ran.
+    // Deliberately low-entropy and self-describing: a random-looking
+    // literal here trips the gitleaks keyword+entropy rule in CI.
+    password: "E2e-test-password-123!",
+    name: "E2E Tester",
   };
 }
 

--- a/apps/onboarding/tests/e2e/resume.spec.ts
+++ b/apps/onboarding/tests/e2e/resume.spec.ts
@@ -27,7 +27,7 @@ test("survives full browser close between submit and verify", async ({
   browser,
   request,
 }) => {
-  const { email, slug, businessName, password } = uniqueEmail("resume");
+  const { email, slug, businessName, password, name } = uniqueEmail("resume");
 
   // ── 1. First context: complete the form ───────────────────────────────
   const first = await browser.newContext();
@@ -98,6 +98,7 @@ test("survives full browser close between submit and verify", async ({
   await expect(secondPage).toHaveURL(/\/onboarding\/set-password/, {
     timeout: 15_000,
   });
+  await secondPage.locator("#name").fill(name);
   await secondPage.locator("#password").fill(password);
   await secondPage.getByRole("button", { name: /create account/i }).click();
   await expect(secondPage).toHaveURL(/\/welcome/, { timeout: 15_000 });

--- a/apps/onboarding/tests/e2e/slug-collision.spec.ts
+++ b/apps/onboarding/tests/e2e/slug-collision.spec.ts
@@ -47,6 +47,7 @@ test("rejects a slug that another tenant has already claimed", async ({
   await expect(page).toHaveURL(/\/onboarding\/set-password/, {
     timeout: 15_000,
   });
+  await page.locator("#name").fill(claim.name);
   await page.locator("#password").fill(claim.password);
   await page.getByRole("button", { name: /create account/i }).click();
   await expect(page).toHaveURL(/\/welcome/, { timeout: 15_000 });
@@ -69,9 +70,16 @@ test("rejects a slug that another tenant has already claimed", async ({
   await expect(freshPage.getByText(/already taken/i)).toBeVisible({
     timeout: 5000,
   });
+  // The button stays ENABLED on a taken slug, deliberately:
+  // OnboardingForm's `canSubmit = !pending && !screenshotUploading`
+  // (:296, rationale at :292-295) -- gating on slug availability left a
+  // mystery-disabled button on first load, so an invalid slug surfaces an
+  // error instead. Stage 1 recorded the same decision for
+  // form-validation.spec.ts; this spec asserted the superseded behaviour
+  // and had never run to find out.
   await expect(
     freshPage.getByRole("button", { name: /send verification link/i }),
-  ).toBeDisabled();
+  ).toBeEnabled();
 
   await fresh.close();
 });

--- a/apps/onboarding/tests/unit/dev-stack-config.spec.ts
+++ b/apps/onboarding/tests/unit/dev-stack-config.spec.ts
@@ -86,6 +86,45 @@ test('no docker-compose service uses a bare command: ["up"]', () => {
   }
 });
 
+// platform-api must reach marketplace-api by its compose name (#858).
+//
+// Its config default is the production k8s DNS name. Unset here, every
+// onboarding Complete fails DNS three times with backoff -- ensure-self-vendor,
+// ensure-self-store, ensure-subscription -- taking ~20s and logging
+// "THIS STORE HAS NO TRIAL CLOCK". The store is still created and the request
+// still returns 200, so nothing fails: the dev stack silently produced
+// trial-less stores, and the e2e specs merely timed out at 15s looking like a
+// backend problem.
+test("platform-api reaches marketplace-api by its compose service name", () => {
+  const yml = readFileSync(join(root, "infra/dev/docker-compose.yml"), "utf8");
+  const block = yml.match(/^ {2}platform-api:\n((?: {4}.*\n|\n)*)/m)?.[1];
+  expect(block, "platform-api service block not found").toBeTruthy();
+  const url = block?.match(/^ {6}MARKETPLACE_API_URL:\s*(\S+)/m)?.[1];
+  expect(
+    url,
+    "platform-api has no MARKETPLACE_API_URL, so it keeps the k8s production " +
+      "default and every onboarding Complete is slow and trial-less",
+  ).toBeTruthy();
+  expect(url).toMatch(/^http:\/\/marketplace-api:/);
+});
+
+// Zitadel mints its bootstrap PAT only when an expiry is declared (#858).
+//
+// With the machine-user keys but no PAT block, v4.15.3 starts cleanly, serves
+// healthz, and writes NOTHING to PATPATH -- so the bootstrap fails later with
+// an empty token file and the cause is three steps upstream.
+test("zitadel declares a first-instance PAT expiry, or no token is minted", () => {
+  const yml = readFileSync(join(root, "infra/dev/docker-compose.yml"), "utf8");
+  const block = yml.match(/^ {2}zitadel:\n((?: {4}.*\n|\n)*)/m)?.[1];
+  expect(block, "zitadel service block not found").toBeTruthy();
+  expect(block).toMatch(/ZITADEL_FIRSTINSTANCE_PATPATH:/);
+  expect(
+    block,
+    "ZITADEL_FIRSTINSTANCE_ORG_MACHINE_PAT_EXPIRATIONDATE is required: " +
+      "without it the machine user exists but no PAT is ever written",
+  ).toMatch(/ZITADEL_FIRSTINSTANCE_ORG_MACHINE_PAT_EXPIRATIONDATE:/);
+});
+
 // A distroless runtime cannot run a shell-based healthcheck (#858).
 //
 // marketplace-api declared `test: ["CMD", "wget", ...]` while its runtime

--- a/infra/dev/docker-compose.yml
+++ b/infra/dev/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     environment:
       POSTGRES_USER: dev
       POSTGRES_PASSWORD: dev
-      POSTGRES_MULTIPLE_DATABASES: platform_api,auth_bff,openfga,marketplace_db
+      POSTGRES_MULTIPLE_DATABASES: platform_api,auth_bff,openfga,marketplace_db,zitadel
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./postgres-init.sh:/docker-entrypoint-initdb.d/init-multiple-dbs.sh:ro
@@ -88,6 +88,84 @@ services:
   # Go services
   # ──────────────────────────────────────────────────────────────────────
 
+  # ─── Zitadel (#858 stage 3) ──────────────────────────────────────────
+  # Pinned to the major tesserix-k8s runs. `start-from-init` creates the
+  # schema, the first instance, its org and a machine user, then serves —
+  # one container instead of the init/setup/start trio, which matters here
+  # because CI waits on it before it can build any Next app.
+  # A named volume is created root-owned, and the zitadel image runs as a
+  # non-root user with no shell to fix it from. Without this, setup dies on
+  # `open /pat/pat: permission denied` at migration 03_default_instance and
+  # the container exits 1 — after appearing to run 40 migrations fine.
+  #
+  # chmod rather than chown: the image has no shell and no /etc/passwd we
+  # can read, so the uid is not knowable from here. Mode 1777 (sticky, like
+  # /tmp) works whatever uid the image ships. Dev/CI only — this volume
+  # holds one throwaway token for an instance rebuilt on every run.
+  zitadel-pat-init:
+    image: alpine:3.19
+    command: ["chmod", "1777", "/pat"]
+    volumes:
+      - zitadel-pat:/pat
+    restart: "no"
+
+  zitadel:
+    image: ghcr.io/zitadel/zitadel:v4.15.3
+    # The masterkey is exactly 32 bytes and is a DEV-ONLY constant: this
+    # instance is created empty on every run and holds nothing but test
+    # fixtures. Do not copy it anywhere a real instance can reach.
+    command: >-
+      start-from-init
+      --masterkey MasterkeyNeedsToHave32Characters
+      --tlsMode disabled
+    environment:
+      ZITADEL_DATABASE_POSTGRES_HOST: postgres
+      ZITADEL_DATABASE_POSTGRES_PORT: "5432"
+      ZITADEL_DATABASE_POSTGRES_DATABASE: zitadel
+      ZITADEL_DATABASE_POSTGRES_USER_USERNAME: dev
+      ZITADEL_DATABASE_POSTGRES_USER_PASSWORD: dev
+      ZITADEL_DATABASE_POSTGRES_USER_SSL_MODE: disable
+      ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME: dev
+      ZITADEL_DATABASE_POSTGRES_ADMIN_PASSWORD: dev
+      ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE: disable
+      # Zitadel resolves the instance from the request's Host header. These
+      # three decide what that domain is, and every caller must send it —
+      # a container-internal service name matches no instance and returns
+      # "Instance not found" (the same scar the k8s bootstrap.py records).
+      ZITADEL_EXTERNALSECURE: "false"
+      # The instance domain is the CONTAINER name, not localhost, because
+      # the only in-stack caller is platform-api and it reaches Zitadel at
+      # http://zitadel:8080 — so its Host header must be `zitadel:8080` for
+      # the instance to resolve at all.
+      #
+      # Consequence for host-side callers (the bootstrap script, any curl):
+      # connect to localhost:8092 but send `Host: zitadel:8080` explicitly,
+      # or every request 404s with "Instance not found".
+      #
+      # Stage 3b, which puts a BROWSER through the OIDC flow, will need a
+      # second instance domain so the same instance answers to both names.
+      ZITADEL_EXTERNALDOMAIN: zitadel
+      ZITADEL_EXTERNALPORT: "8080"
+      ZITADEL_FIRSTINSTANCE_ORG_NAME: mark8ly
+      # The PAT is written here at first start and read by the bootstrap
+      # container. That is the ONLY moment the token is retrievable.
+      ZITADEL_FIRSTINSTANCE_PATPATH: /pat/pat
+      ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_USERNAME: bootstrap
+      ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_NAME: bootstrap
+      # Without an explicit PAT block no token is minted and PATPATH stays
+      # empty — the machine user alone is not enough. Verified against
+      # v4.15.3 by watching /pat stay empty with the two keys above only.
+      ZITADEL_FIRSTINSTANCE_ORG_MACHINE_PAT_EXPIRATIONDATE: "2519-04-01T08:45:00Z"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      zitadel-pat-init:
+        condition: service_completed_successfully
+    volumes:
+      - zitadel-pat:/pat
+    ports:
+      - "8092:8080"
+
   platform-api-migrate:
     build:
       context: ../..
@@ -124,11 +202,25 @@ services:
       target: server
     env_file:
       - .env.local
+      # Written by infra/dev/zitadel-bootstrap.py, and gitignored. Compose
+      # reads env_file when it CREATES the container, so the bootstrap must
+      # run before `up platform-api` -- `make dev-zitadel` does that ordering.
+      # `required: false` keeps `make dev-min` working with no Zitadel at all;
+      # platform-api's ZITADEL_ENABLED then stays at its false default.
+      - path: .env.zitadel
+        required: false
     environment:
       ENV: dev
       HTTP_PORT: "8086"
       DATABASE_URL: postgres://dev:dev@postgres:5432/platform_api?sslmode=disable
       FGA_API_URL: http://openfga:8080
+      # Without this, platform-api keeps its production default
+      # (mark8ly-marketplace-api-admin.mark8ly.svc.cluster.local:8080) and
+      # every onboarding Complete spends ~20s failing DNS three times --
+      # ensure-self-vendor, ensure-self-store and ensure-subscription --
+      # then logs "THIS STORE HAS NO TRIAL CLOCK". The store is created
+      # either way, so the dev stack silently produced trial-less stores.
+      MARKETPLACE_API_URL: http://marketplace-api:8091
       # Phase P: accept-invite links in invitation emails. Host-side
       # admin dev server — container-internal defaults don't resolve
       # for the user clicking the link in their mail client.
@@ -237,3 +329,4 @@ services:
 
 volumes:
   postgres-data:
+  zitadel-pat:

--- a/infra/dev/zitadel-bootstrap.py
+++ b/infra/dev/zitadel-bootstrap.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Bootstrap a blank Zitadel into the shape platform-api needs (mark8ly#858).
+
+A fresh instance has an org and a machine user with a PAT, and nothing else.
+platform-api's ValidateZitadel refuses to start without an org id, an admin
+project id and a login-client token, so CI has to mint the middle two before
+any service that talks to Zitadel can come up.
+
+Deliberately NOT a port of tesserix-k8s's zitadel-bootstrap/files/bootstrap.py.
+That file is a 1048-line reconciler for a long-lived instance: it manages
+branding, SMTP, IDPs and lockout policies, and it explicitly REFUSES to create
+a project ("create it once and commit its ID as expectedId"). This initialises
+a throwaway instance instead. What is borrowed is its hard-won knowledge of the
+API's actual shapes -- that file's header records that every shape is pinned to
+what was observed rather than what the docs claim, and the same rule applies
+here.
+
+Idempotent: safe to re-run against an instance it already bootstrapped, so a
+retried CI step does not fail on "already exists".
+
+Output: writes the three values platform-api needs, in `KEY=value` form, to
+the path given by --env-out. It must be written BEFORE platform-api is created,
+because compose reads env_file at container-create time.
+"""
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+ADMIN_PROJECT = "mark8ly-admin"
+# Must match platform-api's ZITADEL_STAFF_ROLE_KEY default (pkg/config).
+STAFF_ROLE = "mark8ly.staff"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    # The URL we CONNECT to, which on a developer's machine is a published
+    # port and in CI is the same. Distinct from --host below.
+    ap.add_argument("--api", default="http://localhost:8092")
+    # Zitadel resolves which instance a request is for from the Host header,
+    # NOT from the connection. A request to localhost:8092 carrying the
+    # wrong Host gets 404 "Instance not found" -- verified against v4.15.3,
+    # and the single most confusing failure mode in this file.
+    ap.add_argument("--host", default="zitadel:8080")
+    ap.add_argument("--org", default="mark8ly")
+    ap.add_argument("--pat-file", required=True)
+    ap.add_argument("--env-out", required=True)
+    args = ap.parse_args()
+
+    with open(args.pat_file) as fh:
+        token = fh.read().strip()
+    if not token:
+        die(f"{args.pat_file} is empty -- Zitadel mints the PAT only when "
+            "ZITADEL_FIRSTINSTANCE_ORG_MACHINE_PAT_EXPIRATIONDATE is set, and "
+            "only on the very first start against an empty database")
+
+    api = Zitadel(args.api, args.host, token)
+    api.wait_ready()
+
+    org_id = api.org_id(args.org)
+    log(f"org {args.org}: {org_id}")
+
+    project_id = api.ensure_project(org_id, ADMIN_PROJECT)
+    api.ensure_role(org_id, project_id, STAFF_ROLE)
+
+    with open(args.env_out, "w") as fh:
+        fh.write(
+            "# Written by infra/dev/zitadel-bootstrap.py. Do not edit or commit.\n"
+            "ZITADEL_ENABLED=true\n"
+            f"ZITADEL_ISSUER=http://{args.host}\n"
+            f"ZITADEL_ORG_ID={org_id}\n"
+            f"ZITADEL_ADMIN_PROJECT_ID={project_id}\n"
+            f"ZITADEL_LOGIN_CLIENT_TOKEN={token}\n"
+        )
+    log(f"wrote {args.env_out}")
+    return 0
+
+
+class Zitadel:
+    def __init__(self, api: str, host: str, token: str) -> None:
+        self.api, self.host, self.token = api.rstrip("/"), host, token
+
+    def call(self, method, path, body=None, org_id=None):
+        req = urllib.request.Request(
+            f"{self.api}{path}",
+            data=json.dumps(body).encode() if body is not None else None,
+            method=method,
+        )
+        req.add_header("Host", self.host)
+        req.add_header("Authorization", f"Bearer {self.token}")
+        req.add_header("Content-Type", "application/json")
+        if org_id:
+            # The PAT is instance-level; without this the call resolves
+            # against the machine user's own org.
+            req.add_header("x-zitadel-orgid", org_id)
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return resp.status, json.loads(resp.read() or b"{}")
+        except urllib.error.HTTPError as err:
+            raw = err.read()
+            try:
+                return err.code, json.loads(raw or b"{}")
+            except json.JSONDecodeError:
+                return err.code, {"raw": raw.decode(errors="replace")}
+
+    def wait_ready(self, attempts: int = 60) -> None:
+        for _ in range(attempts):
+            try:
+                req = urllib.request.Request(f"{self.api}/debug/healthz")
+                req.add_header("Host", self.host)
+                with urllib.request.urlopen(req, timeout=5) as resp:
+                    if resp.status == 200:
+                        return
+            except Exception:  # noqa: BLE001 - any failure means not ready yet
+                pass
+            time.sleep(3)
+        die(f"zitadel did not become ready at {self.api} (Host: {self.host})")
+
+    def org_id(self, name: str) -> str:
+        status, body = self.call(
+            "POST", "/admin/v1/orgs/_search", {"query": {"limit": 100}}
+        )
+        if status == 404:
+            die(f"404 from {self.api} -- Zitadel resolves the instance from "
+                f"the Host header and got {self.host!r}. Check "
+                "ZITADEL_EXTERNALDOMAIN/PORT match it exactly.")
+        if status != 200:
+            die(f"org search failed: {status} {body}")
+        for org in body.get("result", []):
+            if org["name"] == name:
+                return org["id"]
+        die(f"org {name!r} not found; ZITADEL_FIRSTINSTANCE_ORG_NAME must match")
+
+    def ensure_project(self, org_id: str, name: str) -> str:
+        status, body = self.call(
+            "POST", "/management/v1/projects/_search",
+            {"query": {"limit": 100}}, org_id=org_id,
+        )
+        if status != 200:
+            die(f"project search failed: {status} {body}")
+        existing = next(
+            (p for p in body.get("result", []) if p["name"] == name), None
+        )
+        if existing:
+            project_id = existing["id"]
+            log(f"project {name}: exists ({project_id})")
+        else:
+            status, body = self.call(
+                "POST", "/management/v1/projects",
+                {
+                    "name": name,
+                    # Puts the granted roles in the token, which is how
+                    # platform-api's staff role becomes visible downstream.
+                    "projectRoleAssertion": True,
+                    # Without a role on this project a user gets
+                    # 403 OIDC-foSyH49RvL at FINALIZE -- after a successful
+                    # password check, so it reads as broken auth rather than
+                    # missing setup.
+                    "projectRoleCheck": True,
+                    "hasProjectCheck": False,
+                },
+                org_id=org_id,
+            )
+            if status != 200:
+                die(f"project create failed: {status} {body}")
+            project_id = body["id"]
+            log(f"project {name}: created ({project_id})")
+
+        # Read back rather than trusting the write. Zitadel's protojson omits
+        # false booleans entirely, so a request that silently failed to set
+        # projectRoleCheck is indistinguishable from one that set it to false
+        # -- and a 200 does not prove the field landed.
+        status, body = self.call(
+            "POST", "/management/v1/projects/_search",
+            {"query": {"limit": 100}}, org_id=org_id,
+        )
+        live = next(
+            (p for p in body.get("result", []) if p["id"] == project_id), None
+        )
+        if not live or not live.get("projectRoleCheck", False):
+            die(f"project {name} has projectRoleCheck=false after bootstrap; "
+                "every merchant sign-in would 403 at finalize")
+        return project_id
+
+    def ensure_role(self, org_id: str, project_id: str, role_key: str) -> None:
+        status, body = self.call(
+            "POST", f"/management/v1/projects/{project_id}/roles/_search",
+            {"query": {"limit": 100}}, org_id=org_id,
+        )
+        if status == 200 and any(
+            r.get("key") == role_key for r in body.get("result", [])
+        ):
+            log(f"role {role_key}: exists")
+            return
+        status, body = self.call(
+            "POST", f"/management/v1/projects/{project_id}/roles",
+            {"roleKey": role_key, "displayName": "Merchant staff", "group": ""},
+            org_id=org_id,
+        )
+        # An idempotent re-run races here only if two bootstraps run at once;
+        # ALREADY_EXISTS is the benign outcome and is not an error.
+        if status != 200 and "already exists" not in json.dumps(body).lower():
+            die(f"role create failed: {status} {body}")
+        log(f"role {role_key}: created")
+
+
+def log(message: str) -> None:
+    print(f"[zitadel-bootstrap] {message}", flush=True)
+
+
+def die(message: str) -> None:
+    print(f"[zitadel-bootstrap] FATAL: {message}", file=sys.stderr, flush=True)
+    raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Stage 3a of #858. **All 7 onboarding spec files now pass against a real Zitadel** — 11 passed, 5 skipped, 0 failed, up from 7/5. Does not close the issue: the 13 admin and 2 storefront specs are stage 3b.

## What this adds

**Zitadel v4.15.3** (the major tesserix-k8s runs) in `infra/dev/docker-compose.yml`, plus `infra/dev/zitadel-bootstrap.py` and a `make dev-zitadel` target. One stack definition, two consumers — a developer and CI — so they cannot drift.

The bootstrap is **not** a port of tesserix-k8s's `zitadel-bootstrap/files/bootstrap.py`. That file is a 1048-line reconciler for a long-lived instance that explicitly *refuses* to create a project ("create it once and commit its ID as expectedId"). This initialises a throwaway one in ~200 lines. What is borrowed is its hard-won knowledge of the API's real shapes.

It is idempotent (a retried CI step re-runs cleanly, verified byte-identical output), and it **reads back `projectRoleCheck` rather than trusting the 200** — Zitadel's protojson omits false booleans, so a silently-failed write is indistinguishable from a deliberate false.

## Four Zitadel scars, each found by running it

1. **The instance is resolved from the `Host` header, not the connection.** Correct header → 200; wrong header → **404**, measured. The instance domain is therefore the *container* name (`zitadel:8080`), because platform-api is the only in-stack caller. Host-side callers must send it explicitly; the bootstrap diagnoses a 404 by naming this cause rather than reporting "org not found".
2. **No PAT is minted without an explicit expiry.** With the machine-user keys alone, v4.15.3 starts cleanly, serves healthz, and writes *nothing* to `PATPATH`. Now guarded by a test.
3. **A named volume is root-owned and the image runs non-root with no shell.** Setup died on `open /pat/pat: permission denied` at migration `03_default_instance` — after appearing to run 40 migrations fine. Fixed with a one-shot `chmod 1777` init; `chmod` not `chown` because the image has no `/etc/passwd` to read the uid from.
4. **`projectRoleCheck: true` is not optional.** Without a role on the admin project a user gets `403 OIDC-foSyH49RvL` at *finalize* — after a successful password check, so it reads as broken auth rather than missing setup.

## A defect that made every dev-stack store trial-less

platform-api's `MARKETPLACE_API_URL` default is the **production k8s DNS name**. Unset in compose, every onboarding Complete failed DNS three times with backoff — `ensure-self-vendor`, `ensure-self-store`, `ensure-subscription` — taking **~20 seconds** and logging:

```
onboarding.Complete: ensure subscription ... server misbehaving — THIS STORE HAS NO TRIAL CLOCK
```

The store is still created and the request still returns **200**, so nothing failed. The dev stack silently produced trial-less stores, and the specs merely timed out at 15s looking like a backend problem. Wiring it took the four specs from 4 failed → 2 passed immediately. Guarded by a test.

## The four specs were also carrying spec drift

They were labelled "Zitadel-blocked", and they were — but standing up Zitadel only got them to the *next* failure. Each had drifted while never running, and only a real run could surface it:

| spec | drift |
|---|---|
| all four | a **required name field** they never filled — added when Zitadel needed givenName/familyName. They sat on "Your name is required" |
| all four | the shared test password had **no uppercase and no symbol**, failing the password policy |
| cross-device-verify | asserted a CTA labelled "Open admin dashboard"; it reads **"Sign in to your admin"** (no session is minted for the admin origin, so it is a hand-off) |
| slug-collision | asserted the submit button **disables** on a taken slug. It deliberately does not — `canSubmit = !pending && !screenshotUploading`, rationale at `:292-295`. **Stage 1 recorded this exact decision for `form-validation.spec.ts`**; this spec asserted the superseded behaviour |

**No application behaviour was changed.** Fixing the app to satisfy any of these would have regressed a deliberate decision.

One stale *comment* is worth flagging rather than fixing here: `WelcomeCta.tsx`'s doc comment still says it renders "Open admin dashboard", which is what sent the spec looking for the wrong string.

## Verification

| check | result |
|---|---|
| `make dev-zitadel` from empty volumes | Zitadel + bootstrap + full Tier-D stack up |
| bootstrap idempotency | second run byte-identical, "exists" not "created" |
| bootstrap with a wrong Host | fails naming the Host-header cause, not "org not found" |
| `projectRoleCheck` read-back | `True` (verified on read, not from the 201) |
| the four previously-blocked specs | **4 passed (12.1s)** |
| **whole onboarding suite** | **11 passed, 5 skipped, 0 failed (16.5s)** |
| onboarding unit suite | 122 passed |
| `npm run check-types` | 5/5 |
| `test-ci-contract.py` | 11/11 |
| `prettier --check` | clean |

Both new guards proven to fail against their reverted defects.

## What stays open — stage 3b

- **13 admin specs + 2 storefront specs.** They need a browser through the OIDC flow, which needs `auth-bff`, the admin app's build-time `NEXT_PUBLIC_ZITADEL_*` (so the bootstrap must run before `next build` — a hard ordering constraint), an OIDC app minted by the bootstrap, and a **second instance domain** so the same Zitadel answers to both `zitadel:8080` and a browser-reachable name.
- The design's other two open questions are still open: whether `MODE=both` is faithful to the prod admin/storefront split, and shared vs per-spec fixtures for 13 admin specs.
