### PR TITLE
Run the admin e2e suite against a real stack, without weakening the login guard (#858)

### DIFF
--- a/.github/scripts/test-ci-contract.py
+++ b/.github/scripts/test-ci-contract.py
@@ -467,50 +467,67 @@ class ReusableCIContract(unittest.TestCase):
             + "\n".join(f"  {n}: {v}" for n, v in drifted.items()),
         )
 
-    def test_e2e_onboarding_pr_and_push_watch_the_same_paths(self) -> None:
-        """The onboarding e2e triggers must filter on one path list (#858).
+    def test_e2e_workflows_pr_and_push_watch_the_same_paths(self) -> None:
+        """Every e2e workflow must filter both triggers on one path list (#858).
 
-        This workflow is expensive (a docker compose stack plus a cold Next
-        16 build), so it runs only when a PR touches what it tests. That is
-        only safe while the `pull_request` and `push` path lists agree: a
-        path listed under `push` alone is a path whose breakage is found
-        after the merge instead of on the PR that caused it.
+        These are expensive (a docker compose stack plus cold Next builds), so
+        they run only when a PR touches what they test. That is safe only
+        while `pull_request` and `push` agree: a path listed under `push`
+        alone is a path whose breakage is found after the merge instead of on
+        the PR that caused it.
 
-        It also keeps the workflow self-validating. Because
-        `.github/workflows/e2e-onboarding.yml` is itself in both lists, any
-        PR editing this workflow runs it -- which is the property that was
-        missing when it reached review having never once executed.
+        Each must also watch ITSELF, which is the property that was missing
+        when e2e-onboarding.yml reached review having never once executed --
+        a PR editing the workflow is then a PR that runs it.
 
-        Parsed rather than grepped: PyYAML resolves the bare `on:` key to
-        the boolean True, which is why this reads d[True] with a fallback.
+        Globbed rather than named: e2e-admin.yml was added later and would
+        not have been covered by a test that named only the onboarding one.
+        That is the same mistake the build-context guard made before it was
+        derived rather than restated.
+
+        Parsed rather than grepped: PyYAML resolves the bare `on:` key to the
+        boolean True, which is why this reads d[True] with a fallback.
         """
         try:
             import yaml
         except ImportError:  # pragma: no cover - yaml ships on the runner
             self.skipTest("PyYAML unavailable")
 
-        workflow = yaml.safe_load(
-            (ROOT / ".github/workflows/e2e-onboarding.yml").read_text()
+        workflow_dir = ROOT / ".github/workflows"
+        e2e = sorted(workflow_dir.glob("e2e-*.yml")) + sorted(
+            workflow_dir.glob("e2e-*.yaml")
         )
-        triggers = workflow[True] if True in workflow else workflow["on"]
+        # A rename that dodged the glob would make this vacuously pass.
+        self.assertGreaterEqual(
+            len(e2e), 2, "expected the onboarding and admin e2e workflows"
+        )
 
-        self.assertIn(
-            "pull_request",
-            triggers,
-            "e2e-onboarding.yml lost its pull_request trigger -- without it "
-            "the workflow can reach main having never executed (#858)",
-        )
-        self.assertEqual(
-            triggers["pull_request"]["paths"],
-            triggers["push"]["paths"],
-            "e2e-onboarding.yml's pull_request and push path filters have "
-            "diverged; a path watched only on push is found only after merge",
-        )
-        self.assertIn(
-            ".github/workflows/e2e-onboarding.yml",
-            triggers["pull_request"]["paths"],
-            "e2e-onboarding.yml must watch itself, so a PR editing it runs it",
-        )
+        for path in e2e:
+            workflow = yaml.safe_load(path.read_text())
+            triggers = workflow[True] if True in workflow else workflow["on"]
+
+            # e2e-runnable.yml has no paths filter -- it is the cheap canary
+            # and runs on every PR deliberately.
+            if "paths" not in triggers.get("push", {}):
+                continue
+
+            self.assertIn(
+                "pull_request",
+                triggers,
+                f"{path.name} lost its pull_request trigger -- without it the "
+                "workflow can reach main having never executed (#858)",
+            )
+            self.assertEqual(
+                triggers["pull_request"]["paths"],
+                triggers["push"]["paths"],
+                f"{path.name}'s pull_request and push path filters have "
+                "diverged; a path watched only on push is found only after merge",
+            )
+            self.assertIn(
+                f".github/workflows/{path.name}",
+                triggers["pull_request"]["paths"],
+                f"{path.name} must watch itself, so a PR editing it runs it",
+            )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/e2e-admin.yml
+++ b/.github/workflows/e2e-admin.yml
@@ -1,0 +1,186 @@
+name: E2E (admin, real stack)
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+# =============================================================================
+# mark8ly#858 stage 3b — the admin suite against the same Tier-D stack
+# infra/dev/docker-compose.yml gives a developer: postgres, OpenFGA,
+# Zitadel, platform-api, marketplace-api and auth-bff.
+#
+# Pinned to the FIVE spec files that pass end to end today, gated on exactly
+# 10 passed. The other nine are excluded deliberately and visibly, not
+# silently: each carries UI drift that needs a judgement about whether the
+# app or the spec is right, and guessing bakes a false assertion into CI —
+# the exact failure this issue exists to prevent.
+#
+# Admin /login cannot render on a local stack BY DESIGN (middleware 404s
+# canonical /login without an https {slug}-admin.mark8ly.com returnUrl), so
+# specs mint a real session through auth-bff's existing
+# POST /internal/mint-session and Chromium maps *-admin.mark8ly.com to the
+# local server. Nothing in the app is relaxed to accommodate the tests.
+#
+# Excluded, with reasons:
+#   sign-in                 tests the login FORM, so it cannot use the bypass
+#   stores-multi            asserts create-store switches to it; measured, it
+#                           does not — a product decision, left red on purpose
+#   auth-handoff            not converted; different session pattern
+#   invite-teammate         drift
+#   invite-store-scope      drift
+#   products-bulk-flow      1 of 2 green; copy-to-store toast drift
+#   products-csv-flow       drift
+#   products-media-flow     hangs, uninvestigated
+#   products-variants-flow  hangs, uninvestigated
+# =============================================================================
+on:
+  # Keep these two path lists identical. A path that can break the suite but
+  # only appears under `push` is a path whose breakage is found after merge.
+  pull_request:
+    paths:
+      - "apps/admin/**"
+      - "apps/onboarding/**"
+      - "services/platform-api/**"
+      - "services/marketplace-api/**"
+      - "services/auth-bff/**"
+      - "infra/dev/**"
+      - "infra/openfga/**"
+      - ".github/workflows/e2e-admin.yml"
+  push:
+    branches: [main]
+    paths:
+      - "apps/admin/**"
+      - "apps/onboarding/**"
+      - "services/platform-api/**"
+      - "services/marketplace-api/**"
+      - "services/auth-bff/**"
+      - "infra/dev/**"
+      - "infra/openfga/**"
+      - ".github/workflows/e2e-admin.yml"
+  schedule:
+    - cron: "0 16 * * *" # 02:00 AEST
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  admin:
+    name: admin suite vs real stack
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: "24"
+
+      - name: Bring up the Tier-D stack
+        run: |
+          touch infra/dev/.env.local
+          make dev-zitadel
+
+      - name: Prove the backend is reachable, not merely running
+        run: |
+          for i in $(seq 1 60); do
+            curl -fsS http://localhost:8086/health >/dev/null 2>&1 && break
+            sleep 2
+          done
+          curl -fsS http://localhost:8086/health >/dev/null \
+            || { echo "::error::platform-api never became healthy"; exit 1; }
+          curl -fsS http://localhost:8087/health >/dev/null \
+            || { echo "::error::auth-bff never became healthy — the suite mints sessions through it"; exit 1; }
+          curl -fsS http://localhost:8091/health >/dev/null \
+            || { echo "::error::marketplace-api never became healthy — product seeding goes through it"; exit 1; }
+          curl -fsS -H 'Host: zitadel:8080' http://localhost:8092/debug/healthz >/dev/null \
+            || { echo "::error::zitadel not ready"; exit 1; }
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        working-directory: apps/admin
+        run: npx playwright install --with-deps chromium
+
+      - name: Build onboarding and admin
+        env:
+          PLATFORM_API_URL: http://localhost:8086
+          MARKETPLACE_API_URL: http://localhost:8091
+          AUTH_BFF_URL: http://localhost:8087
+          SESSION_ENCRYPT_KEY: dev-session-encrypt-key-32-bytes
+        # Every admin spec onboards through the onboarding app first, so both
+        # have to be built. Zitadel must already be bootstrapped: the admin
+        # app inlines NEXT_PUBLIC_ZITADEL_* at BUILD time.
+        run: |
+          set -a; . ./infra/dev/.env.zitadel; set +a
+          export NEXT_PUBLIC_ZITADEL_ISSUER=http://localhost:8092
+          export NEXT_PUBLIC_ZITADEL_ADMIN_CLIENT_ID="$ZITADEL_ADMIN_CLIENT_ID"
+          npm run build --workspace @mark8ly/onboarding
+          npm run build --workspace @mark8ly/admin
+
+      - name: Start onboarding and admin
+        env:
+          PLATFORM_API_URL: http://localhost:8086
+          MARKETPLACE_API_URL: http://localhost:8091
+          AUTH_BFF_URL: http://localhost:8087
+          SESSION_ENCRYPT_KEY: dev-session-encrypt-key-32-bytes
+          # Without this admin's middleware role lookup 401s and EVERY
+          # authenticated page fails closed to a login that then 404s.
+          PLATFORM_INTERNAL_AUTH_SECRET: dev-internal-auth-secret-not-a-real-key
+        run: |
+          set -a; . ./infra/dev/.env.zitadel; set +a
+          export NEXT_PUBLIC_ZITADEL_ISSUER=http://localhost:8092
+          export NEXT_PUBLIC_ZITADEL_ADMIN_CLIENT_ID="$ZITADEL_ADMIN_CLIENT_ID"
+          npm run start --workspace @mark8ly/onboarding &
+          npm run start --workspace @mark8ly/admin &
+          for i in $(seq 1 40); do
+            ob=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:4201/onboarding || true)
+            ad=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:4202/pricing || true)
+            [ "$ob" = "200" ] && [ "$ad" = "200" ] && exit 0
+            sleep 3
+          done
+          echo "::error::onboarding ($ob) or admin ($ad) never came up"
+          exit 1
+
+      - name: Run the pinned admin specs and verify the exact pass count
+        working-directory: apps/admin
+        env:
+          ADMIN_URL: http://localhost:4202
+          ONBOARDING_URL: http://localhost:4201
+          API_URL: http://localhost:8086
+          AUTH_BFF_URL: http://localhost:8087
+          MARKETPLACE_API_URL: http://localhost:8091
+          OPENFGA_URL: http://localhost:8089
+          INTERNAL_AUTH_SECRET: dev-internal-auth-secret-not-a-real-key
+        # Same three gates as e2e-onboarding.yml. The pass count is the one
+        # that matters: an all-skipped run also exits 0.
+        run: |
+          set -o pipefail
+          status=0
+          out=$(CI=true npx playwright test \
+            tests/e2e/pricing.spec.ts \
+            tests/e2e/products-list.spec.ts \
+            tests/e2e/settings-role-gate.spec.ts \
+            tests/e2e/settings-stores.spec.ts \
+            tests/e2e/settings-themes.spec.ts \
+            --reporter=line 2>&1) || status=$?
+          printf '%s\n' "$out"
+          fail=0
+          if [ "$status" -ne 0 ]; then
+            echo "::error::playwright exited $status"
+            fail=1
+          fi
+          grep -qE '(^|[^0-9])10 passed' <<<"$out" || {
+            echo "::error::did not see exactly 10 passed — the admin suite is not actually executing and passing"
+            fail=1
+          }
+          if grep -qE '(^|[^0-9])[0-9]+ (failed|timed out)' <<<"$out"; then
+            echo "::error::a failed or timed-out test coexists with the expected pass count"
+            fail=1
+          fi
+          exit $fail
+
+      - name: Dump service logs on failure
+        if: failure()
+        run: docker compose -f infra/dev/docker-compose.yml logs --tail=80

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ dev-zitadel: ## Bring up the Tier-D stack (dev-min + Zitadel, bootstrapped) with
 	@rm -f infra/dev/.pat.tmp
 	$(COMPOSE) up -d openfga-migrate openfga openfga-seed \
 	                platform-api-migrate platform-api-seed platform-api \
-	                marketplace-api-migrate marketplace-api
+	                marketplace-api-migrate marketplace-api \
+	                auth-bff-migrate auth-bff
 
 dev-down: ## Stop the local stack
 	$(COMPOSE) down

--- a/apps/admin/playwright.config.ts
+++ b/apps/admin/playwright.config.ts
@@ -21,6 +21,12 @@ const HOST_MAP = [
 
 export default defineConfig({
   testDir: "./tests/e2e",
+  // 5s (the default) was calibrated when these specs mocked their backend.
+  // Against a real stack the first render for a brand-new tenant has to
+  // reach marketplace-api and platform-api, and the assertion regularly
+  // fires before the RSC stream lands -- producing "element(s) not found"
+  // on headings that demonstrably render (#858).
+  expect: { timeout: 15_000 },
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/apps/admin/playwright.config.ts
+++ b/apps/admin/playwright.config.ts
@@ -26,6 +26,15 @@ export default defineConfig({
   // reach marketplace-api and platform-api, and the assertion regularly
   // fires before the RSC stream lands -- producing "element(s) not found"
   // on headings that demonstrably render (#858).
+  // Every spec here now begins with a REAL onboarding — form, magic link,
+  // set-password, Zitadel user provisioning — which costs ~20s on its own,
+  // so Playwright's 30s default left ~10s for the assertions themselves.
+  //
+  // 60s, not more: measured at 120s the same six specs still failed and the
+  // suite went from 5.8min to 16.5min. Extra budget bought nothing because
+  // those six are hanging on something real, not running out of clock — a
+  // longer timeout would only have hidden that behind a slower suite (#858).
+  timeout: 60_000,
   expect: { timeout: 15_000 },
   fullyParallel: false,
   forbidOnly: !!process.env.CI,

--- a/apps/admin/playwright.config.ts
+++ b/apps/admin/playwright.config.ts
@@ -10,6 +10,15 @@ import { defineConfig, devices } from "@playwright/test";
  *
  * Assumes `make dev` (or equivalent) is already up.
  */
+// Admin's middleware bounces an authenticated merchant to their slug
+// subdomain, and canonical /login 404s without an https slug returnUrl —
+// so the specs have to BE on `{slug}-admin.mark8ly.com`. Chromium maps it
+// to the local server; no DNS entry, no TLS, no hosts-file edit, and
+// nothing in the app is relaxed to accommodate the test (#858).
+const HOST_MAP = [
+  "--host-resolver-rules=MAP *-admin.mark8ly.com 127.0.0.1:4202",
+];
+
 export default defineConfig({
   testDir: "./tests/e2e",
   fullyParallel: false,
@@ -22,6 +31,7 @@ export default defineConfig({
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     video: "retain-on-failure",
+    launchOptions: { args: HOST_MAP },
   },
   projects: [
     {

--- a/apps/admin/tests/e2e/helpers.ts
+++ b/apps/admin/tests/e2e/helpers.ts
@@ -416,3 +416,44 @@ export async function seedProducts(
     expect(res.ok(), `seeding product ${i} failed (${res.status()})`).toBeTruthy();
   }
 }
+
+/**
+ * Give a merchant a SECOND store (#858).
+ *
+ * `copy one product to another store` needs somewhere to copy TO, and a
+ * freshly-onboarded merchant has exactly one store — so the copy dialog had
+ * no target and the spec timed out on a control that could never appear.
+ *
+ * `uid` travels in the BODY here, not a header: platform-api's
+ * createStoreForTenant reads req.UID and answers `missing_uid` otherwise.
+ */
+export async function seedSecondStore(
+  request: APIRequestContext,
+  details: { email: string; slug: string },
+): Promise<string> {
+  const authHeaders = { "X-Internal-Auth": process.env.INTERNAL_AUTH_SECRET ?? "" };
+  const tenantRes = await request.get(
+    `${API_URL}/internal/tenants/by-owner-email?email=${encodeURIComponent(details.email)}`,
+    { headers: authHeaders },
+  );
+  expect(tenantRes.ok(), "by-owner-email failed while adding a store").toBeTruthy();
+  const tenant = (await tenantRes.json()).data as {
+    id: string;
+    owner_user_id: string;
+  };
+
+  const slug = `${details.slug}-outlet`;
+  const res = await request.post(`${API_URL}/internal/tenants/${tenant.id}/stores`, {
+    headers: { ...authHeaders, "Content-Type": "application/json" },
+    data: {
+      uid: tenant.owner_user_id,
+      name: "Outlet",
+      slug,
+      country_code: "US",
+      currency_code: "USD",
+      timezone: "America/New_York",
+    },
+  });
+  expect(res.ok(), `second store create failed (${res.status()})`).toBeTruthy();
+  return slug;
+}

--- a/apps/admin/tests/e2e/helpers.ts
+++ b/apps/admin/tests/e2e/helpers.ts
@@ -82,6 +82,9 @@ export const API_URL = process.env.API_URL ?? "http://localhost:8086";
 // directly — there's no "invite teammate" UI yet, so the tests seed
 // the tuples the UI would create.
 export const OPENFGA_URL = process.env.OPENFGA_URL ?? "http://localhost:8089";
+// auth-bff. Only signInAsOwner talks to it directly, via the internal
+// mint-session endpoint — see that helper for why.
+export const AUTH_BFF_URL = process.env.AUTH_BFF_URL ?? "http://localhost:8087";
 
 /**
  * Build a unique email + slug + business name per test run so Postgres
@@ -184,7 +187,10 @@ export async function completeOnboarding(
     await currencyTrigger.click();
     await page.getByRole("option", { name: /usd/i }).first().click();
   }
-  await page.getByRole("button", { name: /get my store ready/i }).click();
+  // "Send verification link", not "get my store ready" — the label
+  // changed and this helper had never run to notice. apps/onboarding's
+  // own specs already use the current label.
+  await page.getByRole("button", { name: /send verification link/i }).click();
   await expect(page).toHaveURL(/\/onboarding\/check-inbox/, {
     timeout: 10_000,
   });
@@ -205,4 +211,97 @@ export async function completeOnboarding(
   await expect(page).toHaveURL(/\/welcome/, { timeout: 15_000 });
 
   return details;
+}
+
+/**
+ * Sign a merchant in WITHOUT driving the login form (#858 stage 3b).
+ *
+ * The form cannot render on a local stack, and that is deliberate rather
+ * than broken: `middleware.ts` 404s canonical `/login` unless it carries a
+ * valid `returnUrl`, and `isValidSlugReturnUrl` requires `https:` plus a
+ * `{slug}-admin.mark8ly.{com,dev}` host. No local HTTP origin can satisfy
+ * both, so for twelve specs the sign-in step is an unreachable prelude to
+ * the thing actually under test.
+ *
+ * So we mint the session directly, the same way break-glass login does —
+ * auth-bff's existing `POST /internal/mint-session`, guarded by
+ * X-Internal-Auth and an auth_context allow-list. Nothing test-only is
+ * added to production, and the cookie is the real one: the same signer,
+ * the same shape, validated through the same `/auth/session` round trip.
+ *
+ * `sign-in.spec.ts` deliberately does NOT use this — it is the spec that
+ * tests the login form, so bypassing the form would make it assert nothing.
+ *
+ * The returned context is pinned to the tenant's slug host. That is not a
+ * convenience: on the canonical host an authenticated merchant is bounced
+ * to their slug subdomain, and `{slug}-admin.mark8ly.com` is reachable in
+ * tests only because playwright.config.ts maps it to 127.0.0.1 (see the
+ * `--host-resolver-rules` launch arg there).
+ */
+export async function signInAsOwner(
+  browser: import("@playwright/test").Browser,
+  request: APIRequestContext,
+  details: { email: string; slug: string },
+): Promise<import("@playwright/test").BrowserContext> {
+  const secret = process.env.INTERNAL_AUTH_SECRET ?? "";
+  if (!secret) {
+    throw new Error(
+      "INTERNAL_AUTH_SECRET is unset — auth-bff's mint-session endpoint " +
+        "fails closed (503 not_configured) without it, and platform-api's " +
+        "/internal lookups 401. Set it to the value in infra/dev/docker-compose.yml.",
+    );
+  }
+  const authHeaders = { "X-Internal-Auth": secret };
+
+  // Resolves BOTH ids in one call: the tenant, and owner_user_id — the
+  // Zitadel uid platform-api recorded at onboarding. The session must
+  // carry the uid, not the email: middleware's role lookup is
+  // /internal/tenants/:id/me?uid=.
+  const tenantRes = await request.get(
+    `${API_URL}/internal/tenants/by-owner-email?email=${encodeURIComponent(details.email)}`,
+    { headers: authHeaders },
+  );
+  expect(
+    tenantRes.ok(),
+    `by-owner-email failed for ${details.email} (${tenantRes.status()})`,
+  ).toBeTruthy();
+  const tenant = (await tenantRes.json()).data as {
+    id: string;
+    owner_user_id: string;
+  };
+
+  const mintRes = await request.post(`${AUTH_BFF_URL}/internal/mint-session`, {
+    headers: authHeaders,
+    data: {
+      tenant_id: tenant.id,
+      tenant_slug: details.slug,
+      user_id: tenant.owner_user_id,
+      email: details.email,
+      auth_context: "staff",
+      ttl_seconds: 3600,
+    },
+  });
+  expect(
+    mintRes.ok(),
+    `mint-session failed (${mintRes.status()})`,
+  ).toBeTruthy();
+
+  // The response is a whole Set-Cookie header VALUE; we need just the
+  // cookie's own value to hand to addCookies.
+  const setCookie = ((await mintRes.json()).set_cookie ?? "") as string;
+  const value = setCookie.split(";")[0]?.split("=").slice(1).join("=") ?? "";
+  expect(value, "mint-session returned no cookie value").not.toBe("");
+
+  const ctx = await browser.newContext({
+    baseURL: `http://${details.slug}-admin.mark8ly.com`,
+  });
+  await ctx.addCookies([
+    {
+      name: "m8_session",
+      value,
+      domain: `${details.slug}-admin.mark8ly.com`,
+      path: "/",
+    },
+  ]);
+  return ctx;
 }

--- a/apps/admin/tests/e2e/helpers.ts
+++ b/apps/admin/tests/e2e/helpers.ts
@@ -292,6 +292,31 @@ export async function signInAsOwner(
   const value = setCookie.split(";")[0]?.split("=").slice(1).join("=") ?? "";
   expect(value, "mint-session returned no cookie value").not.toBe("");
 
+  // Wait for the merchant's role to be READABLE before handing back a
+  // context. onboarding Complete returns before the FGA owner tuple is
+  // visible to platform-api, and admin's middleware fails closed on a
+  // missing role: it bounces to canonical /login, which then 404s. The
+  // spec sees "heading not found" on a page that renders perfectly a
+  // second later, so this presented as spec drift in fifteen different
+  // places rather than as one race.
+  //
+  // Polling the exact endpoint the middleware itself calls, rather than
+  // sleeping: this is done when the thing that gates rendering says so.
+  let role: string | undefined;
+  for (let attempt = 0; attempt < 30 && !role; attempt++) {
+    const meRes = await request.get(
+      `${API_URL}/internal/tenants/${tenant.id}/me?uid=${encodeURIComponent(tenant.owner_user_id)}`,
+      { headers: authHeaders },
+    );
+    if (meRes.ok()) role = ((await meRes.json()).data ?? {}).role;
+    if (!role) await new Promise((r) => setTimeout(r, 500));
+  }
+  expect(
+    role,
+    `owner role never became visible for tenant ${tenant.id} — admin's ` +
+      "middleware would bounce every page to a login that 404s",
+  ).toBeTruthy();
+
   const ctx = await browser.newContext({
     baseURL: `http://${details.slug}-admin.mark8ly.com`,
   });

--- a/apps/admin/tests/e2e/helpers.ts
+++ b/apps/admin/tests/e2e/helpers.ts
@@ -92,6 +92,7 @@ export function uniqueEmail(label = "admin-e2e"): {
   slug: string;
   businessName: string;
   password: string;
+  name: string;
 } {
   const stamp = `${Date.now().toString(36)}${Math.floor(
     Math.random() * 1e4,
@@ -103,7 +104,15 @@ export function uniqueEmail(label = "admin-e2e"): {
     businessName: `${label} ${stamp}`,
     // Phase M: the set-password page collects this after the magic link
     // is consumed. Stable per call so the admin sign-in spec can reuse it.
-    password: "e2e-test-password-123",
+    // Must satisfy the onboarding password policy (>=12 chars with upper,
+    // lower, digit AND symbol). The old value had neither an uppercase
+    // letter nor a symbol; every completeOnboarding() bounced on the policy
+    // message. Same drift #858 stage 3a fixed in the onboarding suite.
+    // Deliberately low-entropy: a random-looking literal trips gitleaks.
+    password: "E2e-test-password-123!",
+    // The set-password step requires a name -- Zitadel needs a
+    // givenName/familyName and platform-api splits this single field.
+    name: "E2E Tester",
   };
 }
 
@@ -158,6 +167,7 @@ export async function completeOnboarding(
   slug: string;
   businessName: string;
   password: string;
+  name: string;
 }> {
   const details = uniqueEmail(label);
 
@@ -189,6 +199,7 @@ export async function completeOnboarding(
   await expect(page).toHaveURL(/\/onboarding\/set-password/, {
     timeout: 15_000,
   });
+  await page.locator("#name").fill(details.name);
   await page.locator("#password").fill(details.password);
   await page.getByRole("button", { name: /create account/i }).click();
   await expect(page).toHaveURL(/\/welcome/, { timeout: 15_000 });

--- a/apps/admin/tests/e2e/helpers.ts
+++ b/apps/admin/tests/e2e/helpers.ts
@@ -85,6 +85,9 @@ export const OPENFGA_URL = process.env.OPENFGA_URL ?? "http://localhost:8089";
 // auth-bff. Only signInAsOwner talks to it directly, via the internal
 // mint-session endpoint — see that helper for why.
 export const AUTH_BFF_URL = process.env.AUTH_BFF_URL ?? "http://localhost:8087";
+// marketplace-api. Used only by seedProducts — see that helper.
+export const MARKETPLACE_API_URL =
+  process.env.MARKETPLACE_API_URL ?? "http://localhost:8091";
 
 /**
  * Build a unique email + slug + business name per test run so Postgres
@@ -329,4 +332,87 @@ export async function signInAsOwner(
     },
   ]);
   return ctx;
+}
+
+/**
+ * Create products for a freshly-onboarded merchant (#858).
+ *
+ * Several specs assert against a populated products table but onboard a
+ * FRESH tenant, which has none — they were written when the suite mocked
+ * its backend and something else supplied the rows. Against a real stack
+ * they saw the empty state, which surfaced as "table tbody tr not visible"
+ * and read like a rendering bug.
+ *
+ * Per-spec, not a shared fixture. Shared mutable fixtures across specs are
+ * what made the old suite ordering-dependent, and the design for #858
+ * called that out explicitly as the thing to avoid.
+ *
+ * Goes through marketplace-api's real admin API as the real owner. The
+ * owner's uid matters: the route authorises against an FGA role, so a
+ * synthetic user id gets a 404 that looks like a missing store.
+ */
+export async function seedProducts(
+  request: APIRequestContext,
+  details: { email: string },
+  count = 3,
+): Promise<void> {
+  const secret = process.env.INTERNAL_AUTH_SECRET ?? "";
+  const authHeaders = { "X-Internal-Auth": secret };
+
+  const tenantRes = await request.get(
+    `${API_URL}/internal/tenants/by-owner-email?email=${encodeURIComponent(details.email)}`,
+    { headers: authHeaders },
+  );
+  expect(tenantRes.ok(), "by-owner-email failed while seeding").toBeTruthy();
+  const tenant = (await tenantRes.json()).data as {
+    id: string;
+    owner_user_id: string;
+  };
+
+  // marketplace-api keeps its OWN store rows (created by ensure-self-store
+  // during onboarding), with different ids from platform-api's. Ask it.
+  const scope = {
+    "X-Tenant-Id": tenant.id,
+    "X-User-Id": tenant.owner_user_id,
+  };
+  // Poll: onboarding Complete calls ensure-self-store/ensure-self-vendor on
+  // marketplace-api, and neither the store row nor the marketplace-store FGA
+  // grant is readable the instant Complete returns. Same race as the owner
+  // role in signInAsOwner — an immediate call 404s, which reads as "this
+  // merchant has no store" rather than "not yet".
+  let stores: { id: string }[] = [];
+  for (let attempt = 0; attempt < 30 && stores.length === 0; attempt++) {
+    const res = await request.get(`${MARKETPLACE_API_URL}/api/v1/admin/stores`, {
+      headers: scope,
+    });
+    if (res.ok()) stores = ((await res.json()).data ?? []) as { id: string }[];
+    if (stores.length === 0) await new Promise((r) => setTimeout(r, 500));
+  }
+  expect(
+    stores.length,
+    "marketplace-api never reported a store for this merchant — " +
+      "ensure-self-store did not land",
+  ).toBeGreaterThan(0);
+  const storeId = stores[0]!.id;
+
+  for (let i = 1; i <= count; i++) {
+    const res = await request.post(
+      `${MARKETPLACE_API_URL}/api/v1/admin/stores/${storeId}/products`,
+      {
+        headers: { ...scope, "Content-Type": "application/json" },
+        data: {
+          title: `Seeded Product ${i}`,
+          status: "active",
+          variants: [
+            {
+              sku: `SEED-${i}`,
+              price: "10.00",
+              inventory_quantity: 5,
+            },
+          ],
+        },
+      },
+    );
+    expect(res.ok(), `seeding product ${i} failed (${res.status()})`).toBeTruthy();
+  }
 }

--- a/apps/admin/tests/e2e/invite-store-scope.spec.ts
+++ b/apps/admin/tests/e2e/invite-store-scope.spec.ts
@@ -48,8 +48,12 @@ test("store-scoped invite grants store role without tenant access", async ({
   const second = uniqueEmail("outlet");
   await ownerPage.goto(`/settings/stores`);
   await ownerPage.getByRole("button", { name: /\+ add store/i }).click();
-  await ownerPage.getByLabel(/store name/i).fill(`${owner.businessName} Outlet`);
-  await ownerPage.getByLabel(/url slug/i).fill(second.slug);
+  // Distinct ids, not getByLabel: the page behind this inline panel
+  // (StoresList.tsx:322 — a <section>, not a dialog) already has a
+  // "Store name" for the current store, so an unscoped label matches
+  // two elements and strict mode correctly refuses.
+  await ownerPage.locator("#new-store-name").fill(`${owner.businessName} Outlet`);
+  await ownerPage.locator("#new-store-slug").fill(second.slug);
   await ownerPage.getByRole("button", { name: /create store/i }).click();
   await expect(ownerPage).toHaveURL(/\/settings\/general/, { timeout: 15_000 });
 

--- a/apps/admin/tests/e2e/invite-store-scope.spec.ts
+++ b/apps/admin/tests/e2e/invite-store-scope.spec.ts
@@ -4,6 +4,7 @@ import {
   ADMIN_URL,
   API_URL,
   completeOnboarding,
+  signInAsOwner,
   uniqueEmail,
 } from "./helpers";
 
@@ -41,16 +42,11 @@ test("store-scoped invite grants store role without tenant access", async ({
   await signupCtx.close();
 
   // ── 2. Sign in + add second store ────────────────────────────
-  const ownerCtx = await browser.newContext();
+  const ownerCtx = await signInAsOwner(browser, request, owner);
   const ownerPage = await ownerCtx.newPage();
-  await ownerPage.goto(`${ADMIN_URL}/login`);
-  await ownerPage.getByLabel(/email address/i).fill(owner.email);
-  await ownerPage.getByLabel(/password/i).fill(owner.password);
-  await ownerPage.getByRole("button", { name: /^sign in$/i }).click();
-  await expect(ownerPage).toHaveURL(/\/dashboard/, { timeout: 15_000 });
 
   const second = uniqueEmail("outlet");
-  await ownerPage.goto(`${ADMIN_URL}/settings/stores`);
+  await ownerPage.goto(`/settings/stores`);
   await ownerPage.getByRole("button", { name: /\+ add store/i }).click();
   await ownerPage.getByLabel(/store name/i).fill(`${owner.businessName} Outlet`);
   await ownerPage.getByLabel(/url slug/i).fill(second.slug);
@@ -58,7 +54,7 @@ test("store-scoped invite grants store role without tenant access", async ({
   await expect(ownerPage).toHaveURL(/\/settings\/general/, { timeout: 15_000 });
 
   // ── 3. Team page — scope toggle is now visible ──────────────
-  await ownerPage.goto(`${ADMIN_URL}/settings/team`);
+  await ownerPage.goto(`/settings/team`);
   await expect(ownerPage.getByTestId("invite-scope")).toBeVisible();
 
   // ── 4. Flip to "Specific store", pick the outlet, role=manager

--- a/apps/admin/tests/e2e/invite-teammate.spec.ts
+++ b/apps/admin/tests/e2e/invite-teammate.spec.ts
@@ -4,6 +4,7 @@ import {
   ADMIN_URL,
   API_URL,
   completeOnboarding,
+  signInAsOwner,
   uniqueEmail,
 } from "./helpers";
 
@@ -42,16 +43,10 @@ test("owner invites viewer → invitee accepts via password → lands in read-on
   await signupCtx.close();
 
   // ── 2. Sign in + navigate to /settings/team ─────────────────────
-  const ownerCtx = await browser.newContext();
+  const ownerCtx = await signInAsOwner(browser, request, owner);
   const ownerPage = await ownerCtx.newPage();
 
-  await ownerPage.goto(`${ADMIN_URL}/login`);
-  await ownerPage.getByLabel(/email address/i).fill(owner.email);
-  await ownerPage.getByLabel(/password/i).fill(owner.password);
-  await ownerPage.getByRole("button", { name: /^sign in$/i }).click();
-  await expect(ownerPage).toHaveURL(/\/dashboard/, { timeout: 15_000 });
-
-  await ownerPage.goto(`${ADMIN_URL}/settings/team`);
+  await ownerPage.goto(`/settings/team`);
   await expect(
     ownerPage.getByRole("heading", { name: /^team$/i }),
   ).toBeVisible();

--- a/apps/admin/tests/e2e/products-bulk-flow.spec.ts
+++ b/apps/admin/tests/e2e/products-bulk-flow.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import {
   completeOnboarding,
+  seedProducts,
   signInAsOwner,
 } from "./helpers";
 
@@ -28,6 +29,9 @@ test.describe("M7d bulk actions", () => {
     const signupPage = await signupCtx.newPage();
     const details = await completeOnboarding(signupPage, request, "m7d-bulk");
     await signupCtx.close();
+
+    // A fresh tenant has no products; these assertions need rows.
+    await seedProducts(request, details);
 
     const ctx = await signInAsOwner(browser, request, details);
     const page = await ctx.newPage();
@@ -60,8 +64,10 @@ test.describe("M7d bulk actions", () => {
     // Wait for toast confirmation
     await expect(page.getByText(/archived/i)).toBeVisible({ timeout: 10_000 });
 
-    // Verify status changed — filter by archived
-    await page.getByLabel(/filter by status/i).selectOption("archived");
+    // Verify status changed — filter by archived.
+    // The status filter is a row of links now, not a <select>
+    // (ProductsListFilters.tsx:83), so selectOption has nothing to drive.
+    await page.getByRole("link", { name: "Archived", exact: true }).click();
     await expect(rows.first()).toBeVisible({ timeout: 5_000 });
 
     await ctx.close();
@@ -76,6 +82,9 @@ test.describe("M7d bulk actions", () => {
     const signupPage = await signupCtx.newPage();
     const details = await completeOnboarding(signupPage, request, "m7d-copy");
     await signupCtx.close();
+
+    // A fresh tenant has no products; these assertions need rows.
+    await seedProducts(request, details);
 
     const ctx = await signInAsOwner(browser, request, details);
     const page = await ctx.newPage();

--- a/apps/admin/tests/e2e/products-bulk-flow.spec.ts
+++ b/apps/admin/tests/e2e/products-bulk-flow.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { ADMIN_URL, completeOnboarding } from "./helpers";
+import {
+  completeOnboarding,
+  signInAsOwner,
+} from "./helpers";
 
 /**
  * M7d — Products bulk actions + copy-to-store E2E flows.
@@ -26,18 +29,11 @@ test.describe("M7d bulk actions", () => {
     const details = await completeOnboarding(signupPage, request, "m7d-bulk");
     await signupCtx.close();
 
-    const ctx = await browser.newContext();
+    const ctx = await signInAsOwner(browser, request, details);
     const page = await ctx.newPage();
 
-    // Sign in
-    await page.goto(`${ADMIN_URL}/login`);
-    await page.getByLabel(/email address/i).fill(details.email);
-    await page.getByLabel(/password/i).fill(details.password);
-    await page.getByRole("button", { name: /^sign in$/i }).click();
-    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
-
     // Navigate to products
-    await page.goto(`${ADMIN_URL}/products`);
+    await page.goto(`/products`);
     await expect(
       page.getByRole("heading", { name: /^products$/i, level: 1 }),
     ).toBeVisible();
@@ -81,18 +77,11 @@ test.describe("M7d bulk actions", () => {
     const details = await completeOnboarding(signupPage, request, "m7d-copy");
     await signupCtx.close();
 
-    const ctx = await browser.newContext();
+    const ctx = await signInAsOwner(browser, request, details);
     const page = await ctx.newPage();
 
-    // Sign in
-    await page.goto(`${ADMIN_URL}/login`);
-    await page.getByLabel(/email address/i).fill(details.email);
-    await page.getByLabel(/password/i).fill(details.password);
-    await page.getByRole("button", { name: /^sign in$/i }).click();
-    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
-
     // Navigate to products
-    await page.goto(`${ADMIN_URL}/products`);
+    await page.goto(`/products`);
 
     // Wait for product rows
     const rows = page.locator("table tbody tr");
@@ -136,7 +125,7 @@ test.describe("M7d bulk actions", () => {
       const storeOptions = page.getByRole("option");
       if ((await storeOptions.count()) > 1) {
         await storeOptions.nth(1).click();
-        await page.goto(`${ADMIN_URL}/products`);
+        await page.goto(`/products`);
         if (firstProductTitle) {
           await expect(page.getByText(firstProductTitle)).toBeVisible({
             timeout: 10_000,

--- a/apps/admin/tests/e2e/products-bulk-flow.spec.ts
+++ b/apps/admin/tests/e2e/products-bulk-flow.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 import {
   completeOnboarding,
   seedProducts,
+  seedSecondStore,
   signInAsOwner,
 } from "./helpers";
 
@@ -85,6 +86,8 @@ test.describe("M7d bulk actions", () => {
 
     // A fresh tenant has no products; these assertions need rows.
     await seedProducts(request, details);
+    // ...and exactly one store, so "copy to store" has no target without this.
+    await seedSecondStore(request, details);
 
     const ctx = await signInAsOwner(browser, request, details);
     const page = await ctx.newPage();

--- a/apps/admin/tests/e2e/products-csv-flow.spec.ts
+++ b/apps/admin/tests/e2e/products-csv-flow.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import {
   completeOnboarding,
+  seedProducts,
   signInAsOwner,
 } from "./helpers";
 
@@ -27,6 +28,9 @@ test.describe("M7e CSV import flow", () => {
     const signupPage = await signupCtx.newPage();
     const details = await completeOnboarding(signupPage, request, "m7e-import");
     await signupCtx.close();
+
+    // A fresh tenant has no products; these assertions need rows.
+    await seedProducts(request, details);
 
     const ctx = await signInAsOwner(browser, request, details);
     const page = await ctx.newPage();
@@ -87,6 +91,9 @@ test.describe("M7e CSV export flow", () => {
     const signupPage = await signupCtx.newPage();
     const details = await completeOnboarding(signupPage, request, "m7e-export");
     await signupCtx.close();
+
+    // A fresh tenant has no products; these assertions need rows.
+    await seedProducts(request, details);
 
     const ctx = await signInAsOwner(browser, request, details);
     const page = await ctx.newPage();

--- a/apps/admin/tests/e2e/products-csv-flow.spec.ts
+++ b/apps/admin/tests/e2e/products-csv-flow.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { ADMIN_URL, completeOnboarding } from "./helpers";
+import {
+  completeOnboarding,
+  signInAsOwner,
+} from "./helpers";
 
 /**
  * M7e — CSV import/export E2E flows.
@@ -25,18 +28,11 @@ test.describe("M7e CSV import flow", () => {
     const details = await completeOnboarding(signupPage, request, "m7e-import");
     await signupCtx.close();
 
-    const ctx = await browser.newContext();
+    const ctx = await signInAsOwner(browser, request, details);
     const page = await ctx.newPage();
 
-    // Sign in
-    await page.goto(`${ADMIN_URL}/login`);
-    await page.getByLabel(/email address/i).fill(details.email);
-    await page.getByLabel(/password/i).fill(details.password);
-    await page.getByRole("button", { name: /^sign in$/i }).click();
-    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
-
     // Navigate to import page
-    await page.goto(`${ADMIN_URL}/products/import`);
+    await page.goto(`/products/import`);
     await expect(
       page.getByRole("heading", { name: /import products/i }),
     ).toBeVisible();
@@ -92,18 +88,11 @@ test.describe("M7e CSV export flow", () => {
     const details = await completeOnboarding(signupPage, request, "m7e-export");
     await signupCtx.close();
 
-    const ctx = await browser.newContext();
+    const ctx = await signInAsOwner(browser, request, details);
     const page = await ctx.newPage();
 
-    // Sign in
-    await page.goto(`${ADMIN_URL}/login`);
-    await page.getByLabel(/email address/i).fill(details.email);
-    await page.getByLabel(/password/i).fill(details.password);
-    await page.getByRole("button", { name: /^sign in$/i }).click();
-    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
-
     // Navigate to products list
-    await page.goto(`${ADMIN_URL}/products`);
+    await page.goto(`/products`);
     await expect(
       page.getByRole("heading", { name: /^products$/i, level: 1 }),
     ).toBeVisible();

--- a/apps/admin/tests/e2e/products-list.spec.ts
+++ b/apps/admin/tests/e2e/products-list.spec.ts
@@ -54,7 +54,15 @@ test("products list renders the empty state for a fresh tenant", async ({
 
   // Filter surface is present even in the empty state
   await expect(page.getByPlaceholder(/search products/i)).toBeVisible();
-  await expect(page.getByLabel(/filter by status/i)).toBeVisible();
+  // The status filter is a row of links under a "Status" heading, not a
+  // labelled control — ProductsListFilters.tsx:83. `getByLabel(/filter by
+  // status/i)` was written against the old select; that aria-label now
+  // exists only on the coupons list. Assert the shape that ships, and
+  // assert an option too so a filter reduced to a bare heading fails.
+  await expect(page.getByText("Status", { exact: true })).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "Active", exact: true }),
+  ).toBeVisible();
 
   // CTA navigates to the stub detail page
   await newProductCta.click();

--- a/apps/admin/tests/e2e/products-list.spec.ts
+++ b/apps/admin/tests/e2e/products-list.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { ADMIN_URL, completeOnboarding } from "./helpers";
+import {
+  completeOnboarding,
+  signInAsOwner,
+} from "./helpers";
 
 /**
  * M7a — Products list page.
@@ -30,16 +33,10 @@ test("products list renders the empty state for a fresh tenant", async ({
   const details = await completeOnboarding(signupPage, request, "m7a");
   await signupCtx.close();
 
-  const ctx = await browser.newContext();
+  const ctx = await signInAsOwner(browser, request, details);
   const page = await ctx.newPage();
 
-  await page.goto(`${ADMIN_URL}/login`);
-  await page.getByLabel(/email address/i).fill(details.email);
-  await page.getByLabel(/password/i).fill(details.password);
-  await page.getByRole("button", { name: /^sign in$/i }).click();
-  await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
-
-  await page.goto(`${ADMIN_URL}/products`);
+  await page.goto(`/products`);
 
   // Editorial header
   await expect(

--- a/apps/admin/tests/e2e/products-media-flow.spec.ts
+++ b/apps/admin/tests/e2e/products-media-flow.spec.ts
@@ -1,7 +1,10 @@
 import path from "node:path";
 import { expect, test, type Page } from "@playwright/test";
 
-import { ADMIN_URL, completeOnboarding } from "./helpers";
+import {
+  completeOnboarding,
+  signInAsOwner,
+} from "./helpers";
 
 /**
  * M7c — Media flow E2E.
@@ -45,17 +48,11 @@ async function signInAndSeedProduct(
   const details = await completeOnboarding(signupPage, request, label);
   await signupCtx.close();
 
-  const ctx = await browser.newContext();
+  const ctx = await signInAsOwner(browser, request, details);
   const page = await ctx.newPage();
 
-  await page.goto(`${ADMIN_URL}/login`);
-  await page.getByLabel(/email address/i).fill(details.email);
-  await page.getByLabel(/password/i).fill(details.password);
-  await page.getByRole("button", { name: /^sign in$/i }).click();
-  await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
-
   // Create the draft product via the UI so media uploads have an id.
-  await page.goto(`${ADMIN_URL}/products/new`);
+  await page.goto(`/products/new`);
   await page.getByLabel(/^title$/i).fill("Linen tee");
   await page.getByLabel(/^handle$/i).fill(`linen-tee-${label}`);
   await page.getByLabel(/^price/i).fill("19.99");

--- a/apps/admin/tests/e2e/products-variants-flow.spec.ts
+++ b/apps/admin/tests/e2e/products-variants-flow.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test, type Page } from "@playwright/test";
 
-import { ADMIN_URL, completeOnboarding } from "./helpers";
+import {
+  completeOnboarding,
+  signInAsOwner,
+} from "./helpers";
 
 /**
  * M7c — Variants flow E2E.
@@ -31,14 +34,8 @@ async function signInFreshAdmin(
   const details = await completeOnboarding(signupPage, request, label);
   await signupCtx.close();
 
-  const ctx = await browser.newContext();
+  const ctx = await signInAsOwner(browser, request, details);
   const page = await ctx.newPage();
-
-  await page.goto(`${ADMIN_URL}/login`);
-  await page.getByLabel(/email address/i).fill(details.email);
-  await page.getByLabel(/password/i).fill(details.password);
-  await page.getByRole("button", { name: /^sign in$/i }).click();
-  await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
 
   return { page, ctx };
 }
@@ -76,7 +73,7 @@ test.describe("M7c products — variants flow", () => {
     const { page, ctx } = await signInFreshAdmin(browser, request, "m7c-var");
 
     // 1. Create a draft product from /products/new.
-    await page.goto(`${ADMIN_URL}/products/new`);
+    await page.goto(`/products/new`);
     await expect(
       page.getByRole("heading", { name: /new product/i }),
     ).toBeVisible();
@@ -154,7 +151,7 @@ test.describe("M7c products — variants flow", () => {
   }) => {
     const { page, ctx } = await signInFreshAdmin(browser, request, "m7c-cap");
 
-    await page.goto(`${ADMIN_URL}/products/new`);
+    await page.goto(`/products/new`);
     await page.getByLabel(/^title$/i).fill("Big matrix");
     await page.getByLabel(/^handle$/i).fill("big-matrix");
     await page.getByLabel(/^price/i).fill("1.00");

--- a/apps/admin/tests/e2e/settings-role-gate.spec.ts
+++ b/apps/admin/tests/e2e/settings-role-gate.spec.ts
@@ -46,6 +46,10 @@ test("viewer sees read-only settings page after role change", async ({
   const ctx = await signInAsOwner(browser, request, details);
   const page = await ctx.newPage();
 
+  // The old login block ended on /dashboard; signInAsOwner hands back a
+  // context, not a landed page, so navigate explicitly (#858).
+  await page.goto("/dashboard");
+
   // Owner path: role badge says "owner".
   await expect(page.getByTestId("role-badge")).toHaveText(/owner/i);
 

--- a/apps/admin/tests/e2e/settings-role-gate.spec.ts
+++ b/apps/admin/tests/e2e/settings-role-gate.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 
 import {
-  ADMIN_URL,
   completeOnboarding,
   fetchPlatformStoreId,
+  signInAsOwner,
   writeFgaTuples,
 } from "./helpers";
 
@@ -43,14 +43,8 @@ test("viewer sees read-only settings page after role change", async ({
   const details = await completeOnboarding(signupPage, request, "role-gate");
   await signupCtx.close();
 
-  const ctx = await browser.newContext();
+  const ctx = await signInAsOwner(browser, request, details);
   const page = await ctx.newPage();
-
-  await page.goto(`${ADMIN_URL}/login`);
-  await page.getByLabel(/email address/i).fill(details.email);
-  await page.getByLabel(/password/i).fill(details.password);
-  await page.getByRole("button", { name: /^sign in$/i }).click();
-  await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
 
   // Owner path: role badge says "owner".
   await expect(page.getByTestId("role-badge")).toHaveText(/owner/i);
@@ -92,7 +86,7 @@ test("viewer sees read-only settings page after role change", async ({
   // ── 4. Navigate to settings — now read-only ────────────────────
   // `/settings/general` merged into `/settings/stores` during the
   // IA restructure; the store identity form lives on the stores page.
-  await page.goto(`${ADMIN_URL}/settings/stores`);
+  await page.goto(`/settings/stores`);
   await expect(page.getByTestId("role-badge")).toHaveText(/viewer/i);
   await expect(page.getByText(/read-only:/i)).toBeVisible();
 

--- a/apps/admin/tests/e2e/settings-stores.spec.ts
+++ b/apps/admin/tests/e2e/settings-stores.spec.ts
@@ -56,9 +56,18 @@ test("settings/stores surfaces onboarding data and saves a name edit", async ({
   // Owner email is read-only but visible
   await expect(page.getByLabel("Owner email")).toHaveValue(details.email);
 
-  // Country + currency from onboarding (US → USD)
-  await expect(page.getByLabel("Country")).toHaveValue("US");
-  await expect(page.getByLabel("Currency")).toHaveValue("USD");
+  // Country + currency from onboarding (US → USD).
+  //
+  // These are read-only DISPLAY fields now (#ro-country / #ro-currency) and
+  // render human names, not codes: "United States", "US Dollar (USD)". The
+  // spec asserted the raw codes and had never run to notice.
+  //
+  // The currency assertion pins the CODE via regex rather than the whole
+  // display string — the code is the invariant that matters (the store bills
+  // in USD); the surrounding name is presentation and can change without
+  // anything being wrong.
+  await expect(page.getByLabel("Country")).toHaveValue("United States");
+  await expect(page.getByLabel("Currency")).toHaveValue(/\(USD\)$/);
 
   // ── 4. Edit the name, save ──────────────────────────────────────────
   const newName = `${details.businessName} Renamed`;

--- a/apps/admin/tests/e2e/settings-stores.spec.ts
+++ b/apps/admin/tests/e2e/settings-stores.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { ADMIN_URL, completeOnboarding } from "./helpers";
+import {
+  completeOnboarding,
+  signInAsOwner,
+} from "./helpers";
 
 /**
  * Phase N — Tenant settings (stores) page.
@@ -31,17 +34,11 @@ test("settings/stores surfaces onboarding data and saves a name edit", async ({
   await signupCtx.close();
 
   // ── 2. Sign in to admin ─────────────────────────────────────────────
-  const ctx = await browser.newContext();
+  const ctx = await signInAsOwner(browser, request, details);
   const page = await ctx.newPage();
 
-  await page.goto(`${ADMIN_URL}/login`);
-  await page.getByLabel(/email address/i).fill(details.email);
-  await page.getByLabel(/password/i).fill(details.password);
-  await page.getByRole("button", { name: /^sign in$/i }).click();
-  await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
-
   // ── 3. Settings page surfaces every onboarding field ───────────────
-  await page.goto(`${ADMIN_URL}/settings/stores`);
+  await page.goto(`/settings/stores`);
   await expect(
     page.getByRole("heading", { name: /^stores$/i, level: 1 }),
   ).toBeVisible();
@@ -87,16 +84,10 @@ test("settings/stores rejects an empty store name", async ({
   const details = await completeOnboarding(signupPage, request, "empty-name");
   await signupCtx.close();
 
-  const ctx = await browser.newContext();
+  const ctx = await signInAsOwner(browser, request, details);
   const page = await ctx.newPage();
 
-  await page.goto(`${ADMIN_URL}/login`);
-  await page.getByLabel(/email address/i).fill(details.email);
-  await page.getByLabel(/password/i).fill(details.password);
-  await page.getByRole("button", { name: /^sign in$/i }).click();
-  await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
-
-  await page.goto(`${ADMIN_URL}/settings/stores`);
+  await page.goto(`/settings/stores`);
   const nameInput = page.getByLabel("Store name");
   await nameInput.fill("   ");
 

--- a/apps/admin/tests/e2e/settings-themes.spec.ts
+++ b/apps/admin/tests/e2e/settings-themes.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { ADMIN_URL, completeOnboarding } from "./helpers";
+import {
+  completeOnboarding,
+  signInAsOwner,
+} from "./helpers";
 
 /**
  * Post-settings-IA-restructure `/settings/storefront` was renamed to
@@ -17,16 +20,10 @@ test("settings/themes saves and persists layout choice", async ({
   const details = await completeOnboarding(signupPage, request, "themes");
   await signupCtx.close();
 
-  const ctx = await browser.newContext();
+  const ctx = await signInAsOwner(browser, request, details);
   const page = await ctx.newPage();
 
-  await page.goto(`${ADMIN_URL}/login`);
-  await page.getByLabel(/email address/i).fill(details.email);
-  await page.getByLabel(/password/i).fill(details.password);
-  await page.getByRole("button", { name: /^sign in$/i }).click();
-  await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
-
-  await page.goto(`${ADMIN_URL}/settings/themes`);
+  await page.goto(`/settings/themes`);
   await expect(
     page.getByRole("heading", { name: /branding/i, level: 1 }),
   ).toBeVisible();

--- a/apps/admin/tests/e2e/settings-themes.spec.ts
+++ b/apps/admin/tests/e2e/settings-themes.spec.ts
@@ -28,14 +28,41 @@ test("settings/themes saves and persists layout choice", async ({
     page.getByRole("heading", { name: /branding/i, level: 1 }),
   ).toBeVisible();
 
+  // /settings/themes was restructured into sections — a "Branding sections"
+  // nav with Identity / Theme / Homepage / Pages / Footer / SEO / Policies /
+  // Advanced. The layout picker moved under "Theme"; this spec predated that
+  // and expected it on the landing section, so it timed out clicking a
+  // control that was never on screen.
+  await page
+    .getByRole("navigation", { name: /branding sections/i })
+    .getByRole("button", { name: /^theme$/i })
+    .click();
+
   const layoutButton = page.getByTestId("layout-bold-promo");
   await layoutButton.click();
   await expect(layoutButton).toHaveAttribute("aria-pressed", "true");
 
   await page.getByTestId("save-storefront-theme").click();
-  await expect(page.getByRole("status")).toContainText(/saved/i);
+  // Two live regions on this page now (the section shell has one of its
+  // own), so a bare getByRole("status") is a strict-mode violation. Filter
+  // to the one carrying the save confirmation rather than taking .first(),
+  // which would pass even if the toast never appeared.
+  // .first() is safe only because the filter already proves the text is
+  // there: if the toast never rendered, the filtered set would be empty and
+  // this would fail rather than silently pass on a nested wrapper.
+  await expect(
+    page.getByRole("status").filter({ hasText: /saved/i }).first(),
+  ).toBeVisible();
 
   await page.reload();
+  // The active section is component state, not part of the URL, so a reload
+  // lands back on Identity — re-open Theme before asserting persistence.
+  // (This is what makes the assertion meaningful: it proves the LAYOUT
+  // survived the round trip, not that the section did.)
+  await page
+    .getByRole("navigation", { name: /branding sections/i })
+    .getByRole("button", { name: /^theme$/i })
+    .click();
   await expect(page.getByTestId("layout-bold-promo")).toHaveAttribute(
     "aria-pressed",
     "true",

--- a/apps/admin/tests/e2e/stores-multi.spec.ts
+++ b/apps/admin/tests/e2e/stores-multi.spec.ts
@@ -54,14 +54,27 @@ test("owner creates a second store, switches, and edits each separately", async 
   // ── 3. Add a second store ────────────────────────────────────
   const second = uniqueEmail("store2");
   await page.getByRole("button", { name: /\+ add store/i }).click();
-  await page.getByLabel(/store name/i).fill(`${owner.businessName} Outlet`);
-  await page.getByLabel(/url slug/i).fill(second.slug);
+  // Distinct ids, not getByLabel: the page behind this inline panel
+  // (StoresList.tsx:322 — a <section>, not a dialog) already has a
+  // "Store name" for the current store, so an unscoped label matches
+  // two elements and strict mode correctly refuses.
+  await page.locator("#new-store-name").fill(`${owner.businessName} Outlet`);
+  await page.locator("#new-store-slug").fill(second.slug);
   // Country + currency + timezone default to US/USD/America/New_York
   await page.getByRole("button", { name: /create store/i }).click();
 
   // Auto-redirects back to /settings/stores after switch-store.
   await expect(page).toHaveURL(/\/settings\/stores/, { timeout: 15_000 });
-  await expect(page.getByLabel("Store name")).toHaveValue(
+  // #name is the CURRENT store's edit field; the add-store panel's is
+  // #new-store-name. Both are labelled "Store name", so the bare label
+  // matches two elements once that panel has been opened.
+  //
+  // KNOWN RED (#858): this asserts that creating a store switches to it —
+  // measured, the form still shows the ORIGINAL store afterwards. Whether
+  // create-then-switch is the intended behaviour is a product decision,
+  // not a locator fix, so this is left failing rather than quietly
+  // rewritten to match whatever the app happens to do today.
+  await expect(page.locator("#name")).toHaveValue(
     `${owner.businessName} Outlet`,
   );
 

--- a/apps/admin/tests/e2e/stores-multi.spec.ts
+++ b/apps/admin/tests/e2e/stores-multi.spec.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "@playwright/test";
 
-import { ADMIN_URL, completeOnboarding, uniqueEmail } from "./helpers";
+import {
+  completeOnboarding,
+  signInAsOwner,
+  uniqueEmail,
+} from "./helpers";
 
 /**
  * Phase Q.2 — multi-store lifecycle.
@@ -39,16 +43,10 @@ test("owner creates a second store, switches, and edits each separately", async 
   await signupCtx.close();
 
   // ── 2. Sign in + stores index ────────────────────────────────
-  const ctx = await browser.newContext();
+  const ctx = await signInAsOwner(browser, request, owner);
   const page = await ctx.newPage();
 
-  await page.goto(`${ADMIN_URL}/login`);
-  await page.getByLabel(/email address/i).fill(owner.email);
-  await page.getByLabel(/password/i).fill(owner.password);
-  await page.getByRole("button", { name: /^sign in$/i }).click();
-  await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
-
-  await page.goto(`${ADMIN_URL}/settings/stores`);
+  await page.goto(`/settings/stores`);
   const initialRows = page.getByTestId("store-row");
   await expect(initialRows).toHaveCount(1);
   await expect(initialRows.first()).toContainText(/current/i);

--- a/infra/dev/docker-compose.yml
+++ b/infra/dev/docker-compose.yml
@@ -257,15 +257,40 @@ services:
       target: server
     env_file:
       - .env.local
+      # Written by infra/dev/zitadel-bootstrap.py before this container is
+      # created (see `make dev-zitadel`). Supplies ZITADEL_ENABLED, the
+      # issuer, org/project ids, the login-client PAT, and the admin OIDC
+      # client id + secret. required:false keeps `make dev-min` working.
+      - path: .env.zitadel
+        required: false
     environment:
       ENV: dev
       HTTP_PORT: "8080"
       DATABASE_URL: postgres://dev:dev@postgres:5432/auth_bff?sslmode=disable
       FGA_API_URL: http://openfga:8080
       SESSION_COOKIE_DOMAIN: localhost
+      # Every one of these is REQUIRED by ValidateZitadel once
+      # ZITADEL_ENABLED is true; auth-bff panics at startup naming the
+      # missing key rather than degrading, which is the right behaviour and
+      # also why they must all be here rather than discovered one restart
+      # at a time.
+      PLATFORM_API_URL: http://platform-api:8086
+      MARKETPLACE_INTERNAL_AUTH_SECRET: dev-internal-auth-secret-not-a-real-key
+      SESSION_ENCRYPT_KEY: dev-session-encrypt-key-32-bytes
+      # Host only (no port), and it MUST have two labels. auth-bff's
+      # NewReturnURLAllowlist rejects a bare "localhost" outright -- a
+      # single label is treated as a bare TLD that would match every domain
+      # under it. The rule is right for production and leaves plain
+      # `localhost` inexpressible, so the local stack uses *.localhost,
+      # which RFC 6761 requires resolvers to send to 127.0.0.1 and which
+      # Chromium honours. Drive the specs at http://admin.localhost:4202.
+      ZITADEL_RETURN_URL_ALLOWED_HOSTS_ADMIN: admin.localhost
+      ZITADEL_RETURN_URL_ALLOWED_HOSTS_STOREFRONT: store.localhost
     depends_on:
       auth-bff-migrate:
         condition: service_completed_successfully
+      zitadel:
+        condition: service_started
     # Host port 8087 → container 8080 (8080 is commonly taken on dev machines)
     ports:
       - "8087:8080"

--- a/infra/dev/docker-compose.yml
+++ b/infra/dev/docker-compose.yml
@@ -221,6 +221,17 @@ services:
       # then logs "THIS STORE HAS NO TRIAL CLOCK". The store is created
       # either way, so the dev stack silently produced trial-less stores.
       MARKETPLACE_API_URL: http://marketplace-api:8091
+      # Guards platform-api's /internal/* routes. Unset, they answer
+      # "not_configured" 503 rather than 401 — fail-closed, but it reads as
+      # a bug. The e2e helpers use /internal/users and
+      # /internal/tenants/by-owner-email to resolve a merchant's uid and
+      # tenant before minting a session, so the local stack must set it.
+      INTERNAL_AUTH_SECRET: dev-internal-auth-secret-not-a-real-key
+      # The SAME value must reach the admin app as
+      # PLATFORM_INTERNAL_AUTH_SECRET. Without it admin's middleware role
+      # lookup (/internal/tenants/:id/me?uid=) 401s, `role` stays unset,
+      # and EVERY authenticated page fails closed to a login that then
+      # 404s on canonical — a valid session that looks like a broken one.
       # Phase P: accept-invite links in invitation emails. Host-side
       # admin dev server — container-internal defaults don't resolve
       # for the user clicking the link in their mail client.

--- a/infra/dev/zitadel-bootstrap.py
+++ b/infra/dev/zitadel-bootstrap.py
@@ -31,6 +31,20 @@ import urllib.error
 import urllib.request
 
 ADMIN_PROJECT = "mark8ly-admin"
+ADMIN_OIDC_APP = "mark8ly-admin-web"
+# auth-bff's ValidateZitadel requires ZITADEL_APPLE_IDP_ID to be non-empty.
+# It is never dereferenced unless a user picks Apple sign-in, which no spec
+# does. A real Apple IDP cannot be created here: Zitadel rejects every
+# private-key encoding we could synthesise (PKCS8 PEM, SEC1 PEM, raw DER,
+# each base64'd) with "Invalid Private Key format (ORG-Fk38d)", and the
+# estate's own zitadel-bootstrap.py never creates one either -- it only
+# UPDATES a provider made by hand in the console, deliberately withholding
+# the .p8. So there is no known-good encoding recorded anywhere to copy.
+#
+# The placeholder is therefore deliberate and load-bearing only for startup.
+# If a spec ever needs Apple sign-in locally, this must become a real IDP
+# and that is a research task, not a config change.
+APPLE_IDP_PLACEHOLDER = "apple-idp-not-configured-locally"
 # Must match platform-api's ZITADEL_STAFF_ROLE_KEY default (pkg/config).
 STAFF_ROLE = "mark8ly.staff"
 
@@ -48,6 +62,7 @@ def main() -> int:
     ap.add_argument("--org", default="mark8ly")
     ap.add_argument("--pat-file", required=True)
     ap.add_argument("--env-out", required=True)
+    ap.add_argument("--admin-redirect", default="http://localhost:4202/login/callback")
     args = ap.parse_args()
 
     with open(args.pat_file) as fh:
@@ -65,6 +80,10 @@ def main() -> int:
 
     project_id = api.ensure_project(org_id, ADMIN_PROJECT)
     api.ensure_role(org_id, project_id, STAFF_ROLE)
+    client_id, client_secret = api.ensure_oidc_app(
+        org_id, project_id, ADMIN_OIDC_APP, args.admin_redirect
+    )
+    google_idp = api.ensure_google_idp(org_id)
 
     with open(args.env_out, "w") as fh:
         fh.write(
@@ -74,6 +93,11 @@ def main() -> int:
             f"ZITADEL_ORG_ID={org_id}\n"
             f"ZITADEL_ADMIN_PROJECT_ID={project_id}\n"
             f"ZITADEL_LOGIN_CLIENT_TOKEN={token}\n"
+            f"ZITADEL_ADMIN_CLIENT_ID={client_id}\n"
+            f"ZITADEL_ADMIN_CLIENT_SECRET={client_secret}\n"
+            f"ZITADEL_ADMIN_REDIRECT_URI={args.admin_redirect}\n"
+            f"ZITADEL_GOOGLE_IDP_ID={google_idp}\n"
+            f"ZITADEL_APPLE_IDP_ID={APPLE_IDP_PLACEHOLDER}\n"
         )
     log(f"wrote {args.env_out}")
     return 0
@@ -184,6 +208,102 @@ class Zitadel:
             die(f"project {name} has projectRoleCheck=false after bootstrap; "
                 "every merchant sign-in would 403 at finalize")
         return project_id
+
+    def ensure_oidc_app(self, org_id, project_id, name, redirect_uri):
+        """Mint the admin web app, returning (client_id, client_secret).
+
+        The secret is readable ONLY in the create response -- there is no
+        endpoint that returns it later. So on a re-run against an app that
+        already exists we regenerate it rather than failing: this instance is
+        rebuilt from empty on every CI run, and a stale secret in .env.zitadel
+        would fail at sign-in with a generic "bad credentials" rather than
+        anything naming the cause.
+        """
+        status, body = self.call(
+            "POST", f"/management/v1/projects/{project_id}/apps/_search",
+            {"query": {"limit": 100}}, org_id=org_id,
+        )
+        if status != 200:
+            die(f"app search failed: {status} {body}")
+        existing = next(
+            (a for a in body.get("result", []) if a.get("name") == name), None
+        )
+        if existing:
+            app_id = existing["id"]
+            status, body = self.call(
+                "POST",
+                f"/management/v1/projects/{project_id}/apps/{app_id}/oidc_config/_generate_client_secret",
+                {}, org_id=org_id,
+            )
+            if status != 200:
+                die(f"secret regenerate failed: {status} {body}")
+            log(f"oidc app {name}: exists, secret regenerated")
+            return existing["oidcConfig"]["clientId"], body["clientSecret"]
+
+        status, body = self.call(
+            "POST", f"/management/v1/projects/{project_id}/apps/oidc",
+            {
+                "name": name,
+                "redirectUris": [redirect_uri],
+                "responseTypes": ["OIDC_RESPONSE_TYPE_CODE"],
+                "grantTypes": [
+                    "OIDC_GRANT_TYPE_AUTHORIZATION_CODE",
+                    "OIDC_GRANT_TYPE_REFRESH_TOKEN",
+                ],
+                "appType": "OIDC_APP_TYPE_WEB",
+                "authMethodType": "OIDC_AUTH_METHOD_TYPE_BASIC",
+                "postLogoutRedirectUris": ["http://localhost:4202/"],
+                # http redirect URIs are rejected outright without this.
+                "devMode": True,
+                "accessTokenType": "OIDC_TOKEN_TYPE_BEARER",
+            },
+            org_id=org_id,
+        )
+        if status != 200:
+            die(f"oidc app create failed: {status} {body}")
+        log(f"oidc app {name}: created ({body['clientId']})")
+        return body["clientId"], body["clientSecret"]
+
+    def ensure_google_idp(self, org_id):
+        """Create a Google IDP so auth-bff's config validation passes.
+
+        Its credentials are placeholders: nothing signs in with Google in
+        CI (sign-in.spec.ts says so explicitly -- the Google popup needs
+        real Google Identity Services). Only the ID has to exist.
+
+        Listed via idps/templates/_search, NOT idps/_search: the v1 search
+        returns an empty list even when providers exist, which reads as
+        "none configured" and makes this create a duplicate on every run.
+        """
+        status, body = self.call(
+            "POST", "/management/v1/idps/templates/_search",
+            {"query": {"limit": 100}}, org_id=org_id,
+        )
+        if status == 200:
+            for idp in body.get("result", []):
+                if idp.get("name") == "Google":
+                    log(f"google idp: exists ({idp['id']})")
+                    return idp["id"]
+        status, body = self.call(
+            "POST", "/management/v1/idps/google",
+            {
+                "name": "Google",
+                "clientId": "e2e-dev-google-client-id",
+                "clientSecret": "e2e-dev-google-client-secret",
+                "scopes": ["openid", "profile", "email"],
+                "providerOptions": {
+                    "isLinkingAllowed": True,
+                    "isCreationAllowed": True,
+                    "isAutoCreation": False,
+                    "isAutoUpdate": False,
+                },
+            },
+            org_id=org_id,
+        )
+        if status != 200:
+            die(f"google idp create failed: {status} {body}")
+        log(f"google idp: created ({body['id']})")
+        return body["id"]
 
     def ensure_role(self, org_id: str, project_id: str, role_key: str) -> None:
         status, body = self.call(


### PR DESCRIPTION
Stage 3b of #858. Takes the admin suite from **1 enforced spec file to 5**, and the estate from **8 to 12** of 23 real spec files running in CI. Does not close the issue.

## The blocker, and why it isn't Zitadel

Admin `/login` **cannot render on any local stack, by design**: `middleware.ts:233` 404s canonical `/login` without a valid `returnUrl`, and `isValidSlugReturnUrl` requires **`https:`** *and* `{slug}-admin.mark8ly.{com,dev}`. Measured — no local origin satisfies both:

```
INVALID  http://localhost:4202/dashboard
INVALID  https://localhost:4202/dashboard
INVALID  http://e2e-admin.localhost:4202/dashboard
VALID    https://acme-admin.mark8ly.com/dashboard
```

So the 13 admin specs were never blocked on Zitadel. Standing it up (stage 3a) didn't move them.

**The fix needs no new production code and no TLS.** auth-bff already ships `POST /internal/mint-session` — guarded by `X-Internal-Auth`, an `auth_context` allowlist, fail-closed on an empty secret. It is what break-glass login uses. Specs mint a real session and Chromium's `--host-resolver-rules` puts them on a real `{slug}-admin.mark8ly.com` host over plain HTTP. **Nothing in the app is relaxed to accommodate a test.** `sign-in.spec.ts` deliberately does not use the bypass — it is the spec that tests the form.

I proposed building a test-only endpoint for this before checking. It already existed.

## Two races that were masquerading as drift

Both presented as "element not found" on pages that render perfectly a second later, across ~15 specs:

1. **The FGA owner tuple is not readable when onboarding `Complete` returns.** Admin's middleware fails closed on a missing role → bounces to a login that 404s. `signInAsOwner` now polls the exact endpoint the middleware calls until the role is visible.
2. **marketplace-api's store row and grant land after `Complete` too** (`ensure-self-store`). `seedProducts` polls for the same reason.

Neither is a sleep; both wait on the thing that actually gates rendering.

## Config that was never set

- **`PLATFORM_INTERNAL_AUTH_SECRET` on the admin app** — without it the middleware's role lookup 401s and *every* authenticated page fails closed. A valid session that reads as a broken one, and the reason my first four attempts bounced.
- **`INTERNAL_AUTH_SECRET` on platform-api** — `/internal/*` answered `not_configured`.

## Fixture work

Several specs assert against a populated products table while onboarding a **fresh** tenant, which has none — they were written when the suite mocked its backend. `seedProducts` and `seedSecondStore` create them **per-spec, through the real admin APIs as the real owner** (the route authorises against an FGA role, so a synthetic uid 404s in a way that looks like a missing store). Per-spec on purpose: shared mutable fixtures are what made the old suite ordering-dependent, and #858's design named that as the thing to avoid.

## Drift repaired, with the reason in each case

| spec | drift |
|---|---|
| `products-list` | status filter is a row of **links** now, not a labelled `<select>`; that aria-label lives only on the coupons list |
| `settings-stores` | Country/Currency are read-only **display** fields (`#ro-country`) rendering "United States" / "US Dollar (USD)", not codes |
| `settings-themes` | the Branding page was restructured into sections; the layout picker moved under **Theme**, and section state is not in the URL so a reload needs re-navigating |
| `settings-role-gate` | my own conversion regression — the old login block ended with a navigation, so the spec was asserting against a blank page |
| `stores-multi`, `invite-store-scope` | "Add a store" is an inline `<section>`, not a dialog; its fields are `#new-store-name` / `#new-store-slug` while the current store's is `#name` |
| `products-bulk-flow` | `selectOption` on a control that is no longer a select |

## What CI enforces now

New `e2e-admin.yml`, pinned to the **5 files that pass end to end**, gated on exactly **10 passed** — plus playwright's exit status and a no-failures check, because an all-skipped run also exits 0. It runs on `pull_request` through the same paths filter as `push`, and **watches itself**, so it cannot reach `main` unexecuted.

The path-filter contract test is now **globbed across `e2e-*.yml`** rather than naming the onboarding one — the same mistake the build-context guard made before it was derived. Proven to fail against a diverged filter on the new workflow.

## Nine files still excluded, visibly and with reasons

`sign-in` (tests the form, cannot use the bypass) · `stores-multi` (**left red on purpose**: it asserts creating a store switches to it; measured, it does not — that is a product decision, not a locator fix, and is noted in-file rather than quietly rewritten) · `auth-handoff` (different session pattern) · `invite-teammate`, `invite-store-scope`, `products-csv-flow`, `products-bulk-flow` (1 of 2 green) · `products-media-flow`, `products-variants-flow` (hangs, uninvestigated).

## Verification

Measured against the live Tier-D stack: **11 of 24 admin tests pass** (was 5). The pinned five run **10 passed in 23.6s**. `tsc` clean, `test-ci-contract.py` 11/11, prettier clean. Both new guards proven against their reverted defects.

One negative result recorded in the config so nobody retries it: raising the test timeout 30s → 120s converted **zero** failures and took the suite from 5.8min to 16.5min. Those specs hang on something real. It sits at 60s.
