### PR TITLE
Repair more admin-spec drift, and surface that CSV import has never worked (#858)

### DIFF
--- a/apps/admin/tests/e2e/auth-handoff.spec.ts
+++ b/apps/admin/tests/e2e/auth-handoff.spec.ts
@@ -28,6 +28,25 @@ import { ADMIN_URL, ONBOARDING_URL, completeOnboarding } from "./helpers";
  *   - platform-api /internal/tenants/:id is broken
  *   - the logout route isn't clearing the cookie
  */
+// KNOWN RED (#858) — this spec describes an architecture that was removed,
+// and it needs a DECISION, not a repair.
+//
+// Its premise is that onboarding mints a session cookie the admin origin
+// then reuses ("Same context = same cookie jar"). That handoff is gone:
+// apps/onboarding/components/onboarding/WelcomeCta.tsx records that no
+// session is minted for the admin origin during onboarding, because admin
+// lives on a different origin ({slug}-admin.mark8ly.com) and no cookie this
+// app sets could reach it. The merchant signs in there once instead.
+//
+// Step 1 also asserts anonymous /dashboard bounces to a 200 /login. On the
+// canonical host /login deliberately 404s without a valid returnUrl
+// (middleware.ts:233), so that assertion cannot hold either.
+//
+// Converting it to signInAsOwner would be worse than leaving it red: the
+// session handoff is the ONLY thing it tests, and minting the session for
+// it would assert nothing. Either rewrite it against the sign-in-once flow
+// or delete it — both are calls for whoever owns that flow.
+
 test("onboarding → admin → dashboard with real tenant → logout", async ({
   page,
   request,

--- a/apps/admin/tests/e2e/helpers.ts
+++ b/apps/admin/tests/e2e/helpers.ts
@@ -322,6 +322,16 @@ export async function signInAsOwner(
 
   const ctx = await browser.newContext({
     baseURL: `http://${details.slug}-admin.mark8ly.com`,
+    // middleware's externalOrigin() (middleware.ts:505) picks the scheme
+    // from x-forwarded-proto, falling back to https for any host that is
+    // not localhost/127.* — so on a *-admin.mark8ly.com host every redirect
+    // it builds points at https://, which nothing here serves. Chromium
+    // then fails the navigation with a bare net::ERR_ABORTED that names
+    // neither the scheme nor the redirect.
+    //
+    // Declaring the scheme is what a local reverse proxy would do, and
+    // keeps the app's production default untouched.
+    extraHTTPHeaders: { "x-forwarded-proto": "http" },
   });
   await ctx.addCookies([
     {

--- a/apps/admin/tests/e2e/invite-store-scope.spec.ts
+++ b/apps/admin/tests/e2e/invite-store-scope.spec.ts
@@ -55,7 +55,11 @@ test("store-scoped invite grants store role without tenant access", async ({
   await ownerPage.locator("#new-store-name").fill(`${owner.businessName} Outlet`);
   await ownerPage.locator("#new-store-slug").fill(second.slug);
   await ownerPage.getByRole("button", { name: /create store/i }).click();
-  await expect(ownerPage).toHaveURL(/\/settings\/general/, { timeout: 15_000 });
+  // `/settings/general` merged into `/settings/stores` in the settings IA
+  // restructure — the same rename invite-teammate.spec.ts:113 and
+  // settings-stores.spec.ts:14 already record. This spec had never run to
+  // notice, so it waited 15s for a URL that no longer exists.
+  await expect(ownerPage).toHaveURL(/\/settings\/stores/, { timeout: 15_000 });
 
   // ── 3. Team page — scope toggle is now visible ──────────────
   await ownerPage.goto(`/settings/team`);

--- a/apps/admin/tests/e2e/products-bulk-flow.spec.ts
+++ b/apps/admin/tests/e2e/products-bulk-flow.spec.ts
@@ -87,6 +87,17 @@ test.describe("M7d bulk actions", () => {
     // A fresh tenant has no products; these assertions need rows.
     await seedProducts(request, details);
     // ...and exactly one store, so "copy to store" has no target without this.
+    //
+    // KNOWN RED (#858): seeding the second store makes the FIRST store's
+    // admin host unreachable — the navigation dies with a bare
+    // net::ERR_ABORTED. Isolated by removing this line: the goto then
+    // succeeds and the test gets as far as the (targetless) copy dialog.
+    //
+    // So creating a store appears to move which host the merchant's admin
+    // lives on. That is the same open product question stores-multi.spec.ts
+    // raises from the other side ("does creating a store switch to it?"),
+    // and it wants an answer before either spec is rewritten to match
+    // whatever today's behaviour happens to be.
     await seedSecondStore(request, details);
 
     const ctx = await signInAsOwner(browser, request, details);
@@ -126,8 +137,19 @@ test.describe("M7d bulk actions", () => {
     // Click copy
     await page.getByRole("button", { name: /^copy$/i }).click();
 
-    // Wait for success feedback
-    await expect(page.getByText(/copied/i)).toBeVisible({ timeout: 10_000 });
+    // Success feedback is the dialog CLOSING — handleCopySubmit
+    // (ProductsList.tsx:98) awaits the copy, closes, and clears the
+    // selection. There is no toast.
+    //
+    // The old assertion waited for text matching /copied/i, which the
+    // dialog's own static helper line ("Copied products will land as
+    // drafts in the target store") satisfies before anything is copied —
+    // so it proved nothing while the dialog was open and found nothing
+    // once it closed. The real verification is the target-store check
+    // below.
+    await expect(
+      page.getByText(/copy product to another store/i),
+    ).toBeHidden({ timeout: 10_000 });
 
     // Switch to the target store and verify the product exists
     // This requires the store switcher UI — skip if not available

--- a/apps/admin/tests/e2e/products-csv-flow.spec.ts
+++ b/apps/admin/tests/e2e/products-csv-flow.spec.ts
@@ -18,6 +18,27 @@ import {
  * - At least one tenant with products seeded
  */
 
+// KNOWN RED (#858) — the SPEC is right and the APP is broken. CSV import
+// does not work in production, and this suite is what found it:
+//
+//   1. apps/admin/lib/api/csvImports.ts:97 builds
+//      /api/v1/admin/stores/{id}/products/csv-imports
+//      marketplace-api serves
+//      /api/v1/admin/stores/{id}/csv-imports          (no /products segment)
+//      The GET therefore lands on /products/:id with id="csv-imports" and
+//      500s on `invalid input syntax for type uuid`.
+//
+//   2. apps/admin/app/(admin)/products/import/page.tsx:67 passes the literal
+//      string "__STORE_ID__" as the store id, so the POST 404s. The page is
+//      a client component with no store id in scope — threading one in is a
+//      product change, not a test fix.
+//
+// apps/admin/lib/api/csvImports.test.ts:71 asserts the WRONG url, so the
+// unit suite has been locking the first bug in. That is the whole argument
+// for this issue: green unit tests, a feature that has never worked.
+//
+// Do not "fix" this spec to match the broken behaviour.
+
 test.describe("M7e CSV import flow", () => {
   test("upload 10-row CSV, redirect to job page, see progress, reach completion", async ({
     browser,
@@ -59,9 +80,18 @@ test.describe("M7e CSV import flow", () => {
       buffer: Buffer.from(csvContent),
     });
 
-    // Preview should show headers
-    await expect(page.getByText("title")).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByText("price")).toBeVisible();
+    // Preview should show headers.
+    //
+    // Scoped to the preview table's <th> cells (CsvPreviewTable.tsx:23): a
+    // bare getByText("title") matched three elements — the column header,
+    // and the column-mapping controls that name the same field — so strict
+    // mode refused. Asserting the COLUMN HEADER is also the thing this step
+    // actually cares about: that the uploaded file was parsed into columns.
+    const previewHeaders = page.getByRole("columnheader");
+    await expect(
+      previewHeaders.filter({ hasText: /^title$/i }),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(previewHeaders.filter({ hasText: /^price$/i })).toBeVisible();
 
     // Submit import
     await page.getByRole("button", { name: /start import/i }).click();


### PR DESCRIPTION
Follow-up to #878. Repairs more admin-spec drift and — more importantly — **finds two real application bugs**. The CI pin does **not** widen: whole-file granularity means 11 passing tests still yield the same 5 pinned files.

## CSV import is broken in the shipped app, and a unit test was holding it in place

The single most valuable thing this suite has produced so far. Two frontend defects, both confirmed against a live stack:

1. **`apps/admin/lib/api/csvImports.ts:97`** builds `/api/v1/admin/stores/{id}/products/csv-imports`. marketplace-api serves `/api/v1/admin/stores/{id}/csv-imports` — **no `/products` segment**. The GET therefore lands on `/products/:id` with `id="csv-imports"`:

```
ERROR msg="unhandled handler error"
  err="product: get by id: ERROR: invalid input syntax for type uuid: \"csv-imports\" (SQLSTATE 22P02)"
GET /api/v1/admin/stores/.../products/csv-imports  status=500
```

2. **`apps/admin/app/(admin)/products/import/page.tsx:67`** passes the literal string `"__STORE_ID__"` as the store id:

```
POST /api/v1/admin/stores/__STORE_ID__/products/csv-imports  status=404
```

**And `apps/admin/lib/api/csvImports.test.ts:71` asserts the wrong URL** — so the unit suite has been locking bug 1 in. Green unit tests, a feature that has never worked. That is the argument for #858 in one example.

Not fixed here: the import page is a client component with no store id in scope, so threading one in is product work, not a test fix. Filed separately.

## `auth-handoff` describes an architecture that was removed

Its premise is that onboarding mints a session the admin origin reuses ("Same context = same cookie jar"). That handoff is gone — `WelcomeCta.tsx` records that no session is minted for the admin origin because admin is a different origin, so the merchant signs in once instead. Its step 1 also expects canonical `/dashboard` to bounce to a **200** `/login`, which deliberately 404s without a valid `returnUrl`.

Converting it to `signInAsOwner` would be worse than leaving it red: the handoff is the only thing it tests. Either rewrite it against sign-in-once or delete it — both are calls for whoever owns that flow.

## Drift repaired

| spec | what was wrong |
|---|---|
| `products-bulk-flow` | the copy success assertion waited for `/copied/i`, which the dialog's own static helper text ("**Copied** products will land as drafts…") satisfies before anything is copied — so it proved nothing while open and found nothing once closed. There is no toast; `handleCopySubmit` just closes the dialog. Now asserts that. **1 of 2 tests green.** |
| `products-csv-flow` | `getByText("title")` matched 3 elements (column header + the mapping controls naming the same field). Now scoped to the preview table's `columnheader` cells — which is also what the step actually cares about. |
| `invite-store-scope` | waited for `/settings/general`, which merged into `/settings/stores` in the settings IA restructure — a rename two other specs already record in comments. |

## One infrastructure fix worth keeping

`signInAsOwner` now sends `x-forwarded-proto: http`. `middleware.ts:505`'s `externalOrigin()` picks the scheme from that header and falls back to **https** for any host that is not localhost — so on a `*-admin.mark8ly.com` host every redirect it builds points at `https://`, which nothing local serves, and Chromium fails the navigation with a bare `net::ERR_ABORTED` naming neither the scheme nor the redirect. Declaring the scheme is what a local reverse proxy would do and leaves the production default untouched.

## A finding that needs a product answer

`products-bulk-flow`'s copy test seeds a second store so the copy dialog has a target. Doing so makes the **first** store's admin host unreachable — `ERR_ABORTED`. Isolated by removing that one line: the navigation then succeeds and the test reaches the (targetless) dialog.

So creating a store appears to move which host the merchant's admin lives on. That is the same question `stores-multi` raises from the other side — *does creating a store switch to it?* — and it wants an answer before either spec is rewritten. Recorded in-file in both places.

Also measured and worth knowing: **a store created through platform-api is not visible to marketplace-api** (2 stores vs 1 for the same tenant). The team page reads from platform-api so it sees both, but anything reading marketplace-api sees one.

## Verification

11 of 24 admin tests pass against the live Tier-D stack. The pinned five still run **10 passed**, unchanged. `tsc` clean, `test-ci-contract.py` 11/11, prettier clean.

Every remaining red file now carries an in-file note naming its cause, so none of them is a mystery: `sign-in` (tests the form) · `stores-multi` and `products-bulk-flow` (the store-switch question) · `products-csv-flow` (app bug) · `auth-handoff` (removed premise) · `invite-teammate`, `invite-store-scope` (drift, still open) · `products-media-flow`, `products-variants-flow` (hangs, uninvestigated).
